### PR TITLE
Add eclipse plugin support

### DIFF
--- a/extras/org.codehaus.groovy.m2eclipse/lifecycle-mapping-metadata.xml
+++ b/extras/org.codehaus.groovy.m2eclipse/lifecycle-mapping-metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lifecycleMappingMetadata>
-	<pluginExecutions>
-		<pluginExecution>
-			<pluginExecutionFilter>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <versionRange>[2.0,)</versionRange>
@@ -14,14 +14,33 @@
           <compilerId>groovy-eclipse-compiler</compilerId>
         </parameters>
       </pluginExecutionFilter>
-			<action>
-				<configurator>
-					<id>org.codehaus.groovy.m2eclipse.configurator</id>
-				</configurator>
-			</action>
-		</pluginExecution>
-		<pluginExecution>
-			<pluginExecutionFilter>
+      <action>
+        <configurator>
+            <id>org.codehaus.groovy.m2eclipse.configurator</id>
+        </configurator>
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-compiler-plugin</artifactId>
+        <versionRange>[0.12.0,)</versionRange>
+        <goals>
+          <goal>compile</goal>
+          <goal>testCompile</goal>
+        </goals>
+        <parameters>
+          <compilerId>groovy-eclipse-compiler</compilerId>
+        </parameters>
+      </pluginExecutionFilter>
+      <action>
+        <configurator>
+            <id>org.codehaus.groovy.m2eclipse.configurator</id>
+        </configurator>
+      </action>
+    </pluginExecution>    
+    <pluginExecution>
+      <pluginExecutionFilter>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-eclipse-compiler</artifactId>
         <versionRange>[2.6.0,)</versionRange>
@@ -29,9 +48,9 @@
           <goal>add-groovy-build-paths</goal>
         </goals>
       </pluginExecutionFilter>
-			<action>
-				<execute />
-			</action>
-		</pluginExecution>
-	</pluginExecutions>
+      <action>
+        <execute />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
 </lifecycleMappingMetadata>


### PR DESCRIPTION
I want to write eclipse plugins in groovy, ex. using
https://github.com/open-archetypes/groovy-eclipse-plugin-archetype.

This requires adding a lifecycle mapping entry to support
tycho-compiler-plugin using the compilerId=groovy-eclipse-compiler

This also requires modifications in the GroovyProjectConfigurator in order
to detect the project uses tycho.

Finally, the m2eclipse-tycho plugin has been updated to support other
coompilerIds in
http://repository.tesla.io:8081/nexus/content/sites/m2e.extras/m2eclipse-tycho/0.6.0/N/0.6.0.201210231015/
Older versions would prevent using groovy as compilerId.

Signed-off-by: Fred Bricon fbricon@gmail.com
