### PR TITLE
Addressing GRECLIPSE-1708

### DIFF
--- a/base/org.codehaus.groovy22/src/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
+++ b/base/org.codehaus.groovy22/src/org/codehaus/groovy/transform/ASTTransformationCollectorCodeVisitor.java
@@ -410,8 +410,13 @@ public class ASTTransformationCollectorCodeVisitor extends ClassCodeVisitorSuppo
         				values = loadedClasses.toArray(new Class<?>[loadedClasses.size()]);
         			}
         			return values;
-        		} else {
-        			
+        		} else if (expr instanceof ClassExpression) {
+        		    String classname = ((ClassExpression)expr).getType().getName();
+        			try {
+                        return new Class[]{ Class.forName(classname,false,transformLoader) };
+                    } catch (ClassNotFoundException e) {
+                        source.getErrorCollector().addError(new SimpleMessage("Ast transform processing, cannot find "+classname, source));
+                    }
         		}
 
         		throw new RuntimeException("nyi implemented in eclipse: need to support: "+expr+" (class="+expr.getClass()+")");


### PR DESCRIPTION
Since Groovy allows it, this code change adjusts `ASTTransformationCollectorCodeVisitor` to also allow the `classes` attribute to be just a single class (or `ClassNode`, specifically). This is needed to address the issue reported in GRECLIPSE-1708, which has the symptom:

```
java.lang.RuntimeException: nyi implemented in eclipse: need to support: org.codehaus.groovy.ast.expr.ClassExpression@4fc15e5[type: transform.PropertyEnhancementTransformation] (class=class org.codehaus.groovy.ast.expr.ClassExpression)
```
