### PR TITLE
GRECLIPSE-1725. Eclipse hangs issue on Greclipse code assist scenario

### DIFF
--- a/base/org.eclipse.jdt.groovy.core/src/org/codehaus/jdt/groovy/integration/internal/MultiplexingCompletionParser.java
+++ b/base/org.eclipse.jdt.groovy.core/src/org/codehaus/jdt/groovy/integration/internal/MultiplexingCompletionParser.java
@@ -10,12 +10,18 @@
  *******************************************************************************/
 package org.codehaus.jdt.groovy.integration.internal;
 
+import org.codehaus.jdt.groovy.internal.compiler.ast.GroovyCompilationUnitDeclaration;
 import org.codehaus.jdt.groovy.internal.compiler.ast.GroovyParser;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.groovy.core.util.ContentTypeUtils;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionParser;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
+import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.Initializer;
+import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
@@ -37,6 +43,42 @@ public class MultiplexingCompletionParser extends CompletionParser {
 			return groovyParser.dietParse(sourceUnit, compilationResult);
 		} else {
 			return super.dietParse(sourceUnit, compilationResult);
+		}
+	}
+
+	@Override
+	public void parseBlockStatements(ConstructorDeclaration cd, CompilationUnitDeclaration unit) {
+		if (!(unit instanceof GroovyCompilationUnitDeclaration)) {
+			super.parseBlockStatements(cd, unit);
+		}
+	}
+
+	@Override
+	public MethodDeclaration parseSomeStatements(int start, int end, int fakeBlocksCount, CompilationUnitDeclaration unit) {
+		if (!(unit instanceof GroovyCompilationUnitDeclaration)) {
+			return super.parseSomeStatements(start, end, fakeBlocksCount, unit);
+		}
+		return null;
+	}
+
+	@Override
+	public void parseBlockStatements(AbstractMethodDeclaration md, CompilationUnitDeclaration unit) {
+		if (!(unit instanceof GroovyCompilationUnitDeclaration)) {
+			super.parseBlockStatements(md, unit);
+		}
+	}
+
+	@Override
+	public void parseBlockStatements(Initializer initializer, TypeDeclaration type, CompilationUnitDeclaration unit) {
+		if (!(unit instanceof GroovyCompilationUnitDeclaration)) {
+			super.parseBlockStatements(initializer, type, unit);
+		}
+	}
+
+	@Override
+	public void parseBlockStatements(MethodDeclaration md, CompilationUnitDeclaration unit) {
+		if (!(unit instanceof GroovyCompilationUnitDeclaration)) {
+			super.parseBlockStatements(md, unit);
 		}
 	}
 


### PR DESCRIPTION
Andy, think it's best if you have a look at this fix. Perhaps you could steer me in the right direction if this is not quite the fix you'd like to see 
I've reproduced this issue with a code snippet from GRECLIPSE-1695 that i fixed not too long ago... Pretty sure I've tested content assist while i was fixing it. Not sure what has changed recently aside for the introduction of MultiplexingCompletionParser. I've tried the same code snippet with JDT CompletionParser and result was still the same. BTW, I could reproduce this problem in 3.5 although i was fixing GRECLIPSE-1695 after 3.5 was released.
