### PR TITLE
GRECLIPSE-1443 fixed

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test12/in/A.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test12/in/A.groovy
@@ -1,0 +1,11 @@
+package p
+
+class A {
+	/**
+	 * f
+	 */
+	def f
+	
+	A{}
+}
+A

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test12/out/A.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test12/out/A.groovy
@@ -1,0 +1,11 @@
+package p
+
+class A {
+	/**
+	 * g
+	 */
+	def g
+	
+	A{}
+}
+A

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameType/testJavadoc1/in/A.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameType/testJavadoc1/in/A.groovy
@@ -1,0 +1,11 @@
+package p;
+/**
+ * A
+ */
+class A{ }
+
+class Other {
+    def x = {
+            A a = new A()
+    }
+}

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameType/testJavadoc1/out/B.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameType/testJavadoc1/out/B.groovy
@@ -1,0 +1,11 @@
+package p;
+/**
+ * B
+ */
+class B{ }
+
+class Other {
+    def x = {
+            B a = new B()
+    }
+}

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/rename/RenameFieldTests.java
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/rename/RenameFieldTests.java
@@ -58,7 +58,7 @@ public class RenameFieldTests extends RefactoringTest {
     private void helper2_0(String typeName, String fieldName,
             String newFieldName, boolean updateReferences,
             boolean createDelegates, boolean renameGetter, boolean renameSetter, 
-            boolean performOnError)
+            boolean performOnError, boolean updateTextual)
             throws Exception {
         ICompilationUnit cu = createCUfromTestFile(getPackageP(), "A");
         try {
@@ -79,6 +79,7 @@ public class RenameFieldTests extends RefactoringTest {
                 descriptor.setRenameGetters(renameGetter);
                 descriptor.setRenameSetters(renameSetter);
                 descriptor.setKeepOriginal(createDelegates);
+                descriptor.setUpdateTextualOccurrences(updateTextual);
                 descriptor.setDeprecateDelegate(true);
             }
             RenameRefactoring refactoring = (RenameRefactoring) createRefactoring(descriptor);
@@ -137,13 +138,13 @@ public class RenameFieldTests extends RefactoringTest {
     }
 
     private void helper2(boolean updateReferences) throws Exception {
-        helper2_0("A", "f", "g", updateReferences, false, false, false, false);
+        helper2_0("A", "f", "g", updateReferences, false, false, false, false, false);
     }
     private void helperPerformOnError(boolean updateReferences) throws Exception {
-        helper2_0("A", "f", "g", updateReferences, false, false, false, true);
+        helper2_0("A", "f", "g", updateReferences, false, false, false, true, false);
     }
     private void helperScript() throws Exception {
-        helper2_0("B", "f", "g", true, false, false, false, false);
+        helper2_0("B", "f", "g", true, false, false, false, false, false);
     }
 
     private void helper2() throws Exception {
@@ -195,12 +196,15 @@ public class RenameFieldTests extends RefactoringTest {
     public void test11() throws Exception {
         createCU(((IPackageFragmentRoot) getPackageP().getParent()).createPackageFragment("o", true, null), "Other.java", 
                 "package o;\npublic class Other { public static int FOO;\n }");
-        helper2_0("o.Other", "FOO", "BAR", true, false, false, false, false);
+        helper2_0("o.Other", "FOO", "BAR", true, false, false, false, false, false);
     }
     public void testScript1() throws Exception {
         helperScript();
     }
     public void testScript2() throws Exception {
         helperScript();
+    }
+    public void test12() throws Exception {
+    	helper2_0("A", "f", "g", true, false, false, false, false, true);
     }
 }

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/rename/RenameTypeTests.java
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/rename/RenameTypeTests.java
@@ -281,4 +281,8 @@ public class RenameTypeTests extends RefactoringTest {
     public void testInner1() throws Exception {
         helperWithTextual("Outer", "A", "B", "Outer", true, false);
     }
+    
+    public void testJavadoc1() throws Exception {
+    	helperWithTextual("A", "A", "B", "B", true, true);
+    }
 }

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/core/rename/JavaRefactoringDispatcher.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/core/rename/JavaRefactoringDispatcher.java
@@ -78,14 +78,15 @@ public class JavaRefactoringDispatcher {
     }
 
     private RenameSupport createTypeRefactoring(IType type) throws CoreException {
-		return RenameSupport.create(type, getNewName(), RenameSupport.UPDATE_REFERENCES);
+		return RenameSupport.create(type, getNewName(), RenameSupport.UPDATE_REFERENCES | RenameSupport.UPDATE_TEXTUAL_MATCHES);
 	}
 
 	private RenameSupport createFieldRefactoring(IField field) throws CoreException {
 		return RenameSupport.create(field, getNewName(), 
 				RenameSupport.UPDATE_REFERENCES | 
 				RenameSupport.UPDATE_GETTER_METHOD |
-				RenameSupport.UPDATE_SETTER_METHOD);
+				RenameSupport.UPDATE_SETTER_METHOD |
+				RenameSupport.UPDATE_TEXTUAL_MATCHES);
 	}
 	
 	private RenameSupport createMethodRefactoring(IMethod method) throws CoreException {


### PR DESCRIPTION
Javadoc renaming feature for fields and types implemented. A couple of tests written.
