### PR TITLE
Compilers on e44

### DIFF
--- a/attic/org.codehaus.groovy/src/org/codehaus/groovy/activator/GroovyActivator.java
+++ b/attic/org.codehaus.groovy/src/org/codehaus/groovy/activator/GroovyActivator.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
 import org.osgi.framework.Bundle;

--- a/base/org.codehaus.groovy.eclipse.compilerResolver/src/org/codehaus/groovy/frameworkadapter/util/CompilerChooser.java
+++ b/base/org.codehaus.groovy.eclipse.compilerResolver/src/org/codehaus/groovy/frameworkadapter/util/CompilerChooser.java
@@ -80,10 +80,8 @@ public class CompilerChooser {
         }
 
         System.out.println("Starting Groovy-Eclipse compiler resolver.  Specified compiler level: " + specifiedVersion.toReadableVersionString());
-        
-        PackageAdmin pkgAdmin = context.getService(context.getServiceReference(org.osgi.service.packageadmin.PackageAdmin.class));
-        
-        Bundle[] bundles = pkgAdmin.getBundles(GROOVY_PLUGIN_ID, null);
+                
+        Bundle[] bundles = Platform.getBundles(GROOVY_PLUGIN_ID, null);
 
         if (bundles == null || bundles.length == 0) {
             System.out.println("No Groovy bundles found...this will cause some problems.");
@@ -114,6 +112,7 @@ public class CompilerChooser {
                         bundle.uninstall();
                     }
                 }
+                PackageAdmin pkgAdmin = context.getService(context.getServiceReference(org.osgi.service.packageadmin.PackageAdmin.class));
                 try {
 					Method method = pkgAdmin.getClass().getMethod("refreshPackages", Bundle[].class, boolean.class, FrameworkListener[].class);
 					if (method == null) {
@@ -131,9 +130,6 @@ public class CompilerChooser {
                 }
             }
         } else {
-            // just use highest version
-//            activeIndex = 0;
-            // no need to uninstall unused bundles since they aren't wired
             for (int i = 0; i < bundles.length; i++) {
                 Bundle bundle = bundles[i];
                 allVersions[i] = bundle.getVersion();
@@ -200,7 +196,6 @@ public class CompilerChooser {
     public SpecifiedVersion getActiveSpecifiedVersion() {
     	if (activeIndex == -1) {
     		return SpecifiedVersion.findVersion(getActiveVersion());
-//			return allSpecifiedVersions.length > 0 ? allSpecifiedVersions[0] : SpecifiedVersion.UNSPECIFIED;
     	} else {
 			return allSpecifiedVersions[activeIndex];
 		}
@@ -218,11 +213,13 @@ public class CompilerChooser {
     
     public Bundle getActiveBundle() {
         if (activeIndex == -1) {
+        	// Check if any of the org.codehaus.groovy bundles are active
         	for (Bundle bundle : Platform.getBundles(GROOVY_PLUGIN_ID, null)) {
         		if (bundle.getState() == Bundle.ACTIVE) {
         			return bundle;
         		}
         	}
+        	// If none active just return the latest version bundle
             return Platform.getBundle(GROOVY_PLUGIN_ID); 
         } else {
             Bundle[] bundles = Platform.getBundles(GROOVY_PLUGIN_ID, allVersions[activeIndex].toString());
@@ -238,14 +235,12 @@ public class CompilerChooser {
         return allSpecifiedVersions;
     }
     
-    public Version getAssociatedVersion(SpecifiedVersion specifiedVersion) {
-//        if (activeIndex >= 0) {
-            for (int i = 0; i < allSpecifiedVersions.length; i++) {
-                if (allSpecifiedVersions[i] == specifiedVersion) {
-                    return allVersions[i];
-                }
-            }
-//        }
-        return null;
-    }
+	public Version getAssociatedVersion(SpecifiedVersion specifiedVersion) {
+		for (int i = 0; i < allSpecifiedVersions.length; i++) {
+			if (allSpecifiedVersions[i] == specifiedVersion) {
+				return allVersions[i];
+			}
+		}
+		return null;
+	}
 }

--- a/base/org.codehaus.groovy18/src/org/codehaus/groovy/activator/GroovyActivator.java
+++ b/base/org.codehaus.groovy18/src/org/codehaus/groovy/activator/GroovyActivator.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base/org.codehaus.groovy20/src/org/codehaus/groovy/activator/GroovyActivator.java
+++ b/base/org.codehaus.groovy20/src/org/codehaus/groovy/activator/GroovyActivator.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base/org.codehaus.groovy21/src/org/codehaus/groovy/activator/GroovyActivator.java
+++ b/base/org.codehaus.groovy21/src/org/codehaus/groovy/activator/GroovyActivator.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base/org.codehaus.groovy22/src/org/codehaus/groovy/activator/GroovyActivator.java
+++ b/base/org.codehaus.groovy22/src/org/codehaus/groovy/activator/GroovyActivator.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base/org.codehaus.groovy23/src/org/codehaus/groovy/activator/GroovyActivator.java
+++ b/base/org.codehaus.groovy23/src/org/codehaus/groovy/activator/GroovyActivator.java
@@ -1,5 +1,5 @@
  /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
A fix to Groovy compiler resolver plugin! Hence, a quick code review would be nice :-)

Fix for Groovy Compilers mix up on Groovy compiler preferences page. Can only be reproduced with Greclipse on e44!

The code in CompilerChooser assumes that if compiler version is not specified than it's the groovy version bundled in the latest version of org.codehaus.groovy plugin available.
Turns out that with e44 M6 this assumption doesn't hold anymore. The plugin loaded all the time is the first installed one. Namely the org.codehaus.groovy 2.1 plugin with Groovy 2.1.8 in it. Consecutive installs of Groovy 2.2 and 2.3 features don't result in the latest org.codehaus.groovy plugin activated.
Looks like the reason behind org.codehaus.groovy version 2.1 being loaded and not the latest is some Eclipse/OSGI magic or defect in Luna M6. However, we should be able to still display the correct version.
Built Greclipse update-site locally for e44 and e43j8
Tested the fix with GGTS 3.5.1 on e44
Tested the fix with GGTS 3.5.1 on e43j8. Verified that behavior is still the same in e43 and the fix doesn't break it.
