### PR TITLE
Robustness for GroovyCompilationUnitTests#testGetModuleNode_7()

### DIFF
--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/model/AbstractGroovyTypeRootTests.java
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/model/AbstractGroovyTypeRootTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2009 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,11 +17,9 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.tests.builder.BuilderTests;
 import org.eclipse.jdt.core.tests.util.Util;
-import org.eclipse.jdt.internal.core.JavaModelManager;
 
 /**
  * 
@@ -32,21 +30,6 @@ public class AbstractGroovyTypeRootTests extends BuilderTests {
 
     public AbstractGroovyTypeRootTests(String name) {
         super(name);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        // discard all working copies in case a previous test has
-        // failed
-        ICompilationUnit[] workingCopies = JavaModelManager.getJavaModelManager().getWorkingCopies(null, true);
-        if (workingCopies != null) {
-    	    for (ICompilationUnit workingCopy : workingCopies) {
-                while (workingCopy.isWorkingCopy()) {
-                    workingCopy.discardWorkingCopy();
-                }
-            }
-        }
-        super.tearDown();
     }
 
     protected IFile getFile(String path) {

--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/model/GroovyCompilationUnitTests.java
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/model/GroovyCompilationUnitTests.java
@@ -34,10 +34,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.tests.util.Util;
-import org.eclipse.jdt.internal.core.DefaultWorkingCopyOwner;
-import org.eclipse.jdt.internal.core.JavaModelManager;
-
-
 
 /**
  * @author Andrew Eisenberg
@@ -50,28 +46,6 @@ public class GroovyCompilationUnitTests extends AbstractGroovyTypeRootTests {
     }
 	public static Test suite() {
 		return buildTestSuite(GroovyCompilationUnitTests.class);
-	}
-	
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-        ICompilationUnit[] units = JavaModelManager.getJavaModelManager().getWorkingCopies(DefaultWorkingCopyOwner.PRIMARY, true);
-        if (units != null) {
-            for (int i = 0; i < units.length; i++) {
-                units[i].discardWorkingCopy();
-            }
-        }
-	}
-		
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-        ICompilationUnit[] units = JavaModelManager.getJavaModelManager().getWorkingCopies(DefaultWorkingCopyOwner.PRIMARY, true);
-        if (units != null) {
-            for (int i = 0; i < units.length; i++) {
-                units[i].discardWorkingCopy();
-            }
-        }
 	}
 	
 	public void testCreateJavaCompilationUnit() throws Exception {

--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests.java
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2014 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
+import org.codehaus.jdt.groovy.model.ModuleNodeMapper;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -28,7 +29,7 @@ import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 import org.eclipse.jdt.core.tests.util.TestVerifier;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.compiler.Compiler;
-import org.eclipse.jdt.internal.core.DefaultWorkingCopyOwner;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 
 /**
  * Base class for Java image builder tests
@@ -57,7 +58,7 @@ public class BuilderTests extends TestCase {
 		String expectingOutput,
 		String expectedError) {
 		TestVerifier verifier = new TestVerifier(false);
-		Vector classpath = new Vector(5);
+		Vector<String> classpath = new Vector<String>(5);
 
 		IPath workspacePath = env.getWorkspaceRootPath();
 
@@ -84,7 +85,7 @@ public class BuilderTests extends TestCase {
 			}
 		}
 
-		verifier.execute(className, (String[]) classpath.toArray(new String[0]));
+		verifier.execute(className, classpath.toArray(new String[0]));
 
 		if (DEBUG) {
 			System.out.println("ERRORS\n"); //$NON-NLS-1$
@@ -303,7 +304,7 @@ public class BuilderTests extends TestCase {
 			printProblems();
 
 		Problem[] rootProblems = env.getProblems();
-		Hashtable actual = new Hashtable(rootProblems.length * 2 + 1);
+		Hashtable<IPath, IPath> actual = new Hashtable<IPath, IPath>(rootProblems.length * 2 + 1);
 		for (int i = 0; i < rootProblems.length; i++) {
 			IPath culprit = rootProblems[i].getResourcePath();
 			actual.put(culprit, culprit);
@@ -314,8 +315,8 @@ public class BuilderTests extends TestCase {
 				assertTrue("missing expected problem with " + expected[i].toString(), false); //$NON-NLS-1$
 
 		if (actual.size() > expected.length) {
-			for (Enumeration e = actual.elements(); e.hasMoreElements();) {
-				IPath path = (IPath) e.nextElement();
+			for (Enumeration<IPath> e = actual.elements(); e.hasMoreElements();) {
+				IPath path = e.nextElement();
 				boolean found = false;
 				for (int i = 0; i < expected.length; ++i) {
 					if (path.equals(expected[i])) {
@@ -384,14 +385,14 @@ public class BuilderTests extends TestCase {
 	/**
 	 * Verifies that the given element has the expected problems.
 	 */
-	protected void expectingProblemsFor(IPath root, List expected) {
+	protected void expectingProblemsFor(IPath root, List<IPath> expected) {
 		expectingProblemsFor(new IPath[] { root }, expected);
 	}
 
 	/**
 	 * Verifies that the given elements have the expected problems.
 	 */
-	protected void expectingProblemsFor(IPath[] roots, List expected) {
+	protected void expectingProblemsFor(IPath[] roots, List<IPath> expected) {
 		Problem[] allProblems = allSortedProblems(roots);
 		assumeEquals("Invalid problem(s)!!!", arrayToString(expected.toArray()), arrayToString(allProblems));
 	}
@@ -526,23 +527,27 @@ public class BuilderTests extends TestCase {
 	 */
 	protected void tearDown() throws Exception {
 		env.resetWorkspace();
-        ICompilationUnit[] wcs = new ICompilationUnit[0];
+        // Discard primary working copies and copies with owner left from failed tests
+        ICompilationUnit[] wcs = null;
         int i = 0;
         do {
-            wcs = JavaCore.getWorkingCopies(DefaultWorkingCopyOwner.PRIMARY);
-            for (ICompilationUnit workingCopy : wcs) {
-                try {
-                    workingCopy.discardWorkingCopy();
-                    workingCopy.close();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+            wcs = JavaModelManager.getJavaModelManager().getWorkingCopies(null, true);
+            if (wcs != null) {
+	            for (ICompilationUnit workingCopy : wcs) {
+	                try {
+	                    workingCopy.discardWorkingCopy();
+	                    workingCopy.close();
+	                } catch (Exception e) {
+	                    e.printStackTrace();
+	                }
+	            }
             }
             i++;
-            if (i > 20) {
+            if (i > 20 && wcs != null) {
                 fail("Could not delete working copies " + wcs);
             }
-        } while (wcs.length > 0);
+        } while (wcs != null && wcs.length > 0);
+        assertTrue("ModuleNodeMapper should be empty when there are no working copies", ModuleNodeMapper.isEmpty());        
 		JavaCore.setOptions(JavaCore.getDefaultOptions());
 		super.tearDown();
 	}

--- a/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/src/org/codehaus/groovy/eclipse/codebrowsing/tests/BrowsingTestCase.java
+++ b/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/src/org/codehaus/groovy/eclipse/codebrowsing/tests/BrowsingTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 SpringSource and others.
+ * Copyright (c) 2009-2014 SpringSource and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -30,7 +30,6 @@ import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.TypeNameRequestor;
 import org.eclipse.jdt.core.tests.builder.BuilderTests;
 import org.eclipse.jdt.core.tests.util.Util;
-import org.eclipse.jdt.internal.core.DefaultWorkingCopyOwner;
 import org.eclipse.jdt.internal.core.ResolvedBinaryField;
 import org.eclipse.jdt.internal.core.ResolvedBinaryMethod;
 import org.eclipse.jdt.internal.core.ResolvedBinaryType;
@@ -49,30 +48,6 @@ public abstract class BrowsingTestCase extends BuilderTests {
     public BrowsingTestCase(String name) {
         super(name);
     }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-        ICompilationUnit[] wcs = new ICompilationUnit[0];
-        int i = 0;
-        do {
-            wcs = JavaCore.getWorkingCopies(DefaultWorkingCopyOwner.PRIMARY);
-            for (ICompilationUnit workingCopy : wcs) {
-                try {
-                    workingCopy.discardWorkingCopy();
-                    workingCopy.close();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-            i++;
-            if (i > 20) {
-                fail("Could not delete working copies " + wcs);
-            }
-        } while (wcs.length > 0);
-    }
-
-
 
     protected IPath createGenericProject() throws Exception {
         IPath projectPath;

--- a/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/src/org/codehaus/groovy/eclipse/codebrowsing/tests/JDTAstPositionTest.java
+++ b/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/src/org/codehaus/groovy/eclipse/codebrowsing/tests/JDTAstPositionTest.java
@@ -19,6 +19,7 @@ import org.codehaus.jdt.groovy.model.GroovyCompilationUnit;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IProblemRequestor;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.AST;
@@ -76,6 +77,28 @@ public class JDTAstPositionTest extends BrowsingTestCase {
         		return problemRequestor;
         	}
         };
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        ICompilationUnit[] wcs = new ICompilationUnit[0];
+        int i = 0;
+        do {
+            wcs = JavaCore.getWorkingCopies(this.workingCopyOwner);
+            for (ICompilationUnit workingCopy : wcs) {
+                try {
+                    workingCopy.discardWorkingCopy();
+                    workingCopy.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+            i++;
+            if (i > 20) {
+                fail("Could not delete working copies " + wcs);
+            }
+        } while (wcs.length > 0);
+        super.tearDown();
     }
 
     public void testAnnotationPositions_STS3822() throws Exception {


### PR DESCRIPTION
Test ModuleNodeMapper cache after each test tear down method.Basic
refactoring and clean up. Discard working copies built from custom working copy owner artifacts.
