### PR TITLE
GRECLIPSE-1696 Fix and tests for type inference of generic method return type

### DIFF
--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/search/GenericInferencingTests.java
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/search/GenericInferencingTests.java
@@ -971,7 +971,86 @@ def h = [8: 1, bb:8]
         assertType(contents, start, end, "java.lang.String");
         assertDeclaringType(contents, start, end, "null");
     }
-    
+
+    // GRECLIPSE-1696
+    // Generic method type inference with @CompileStatic
+    public void testMethod1() throws Exception {
+        String contents = 
+                "import groovy.transform.CompileStatic\n" +
+                "class A {\n" +
+                "    public <T> T myMethod(Class<T> claz) {\n" +
+                "        return null\n" +
+                "    }\n" +
+                "    @CompileStatic\n" +
+                "    static void main(String[] args) {\n" +
+                "        A a = new A()\n" +
+                "        def val = a.myMethod(String)\n" +
+                "        val.trim()\n" +
+                "    }\n" +
+                "}";
+        
+        int start = contents.lastIndexOf("val");
+        int end = start + "val".length();
+        assertType(contents, start, end, "java.lang.String");
+    }
+
+    // Generic method type inference without @CompileStatic
+    public void testMethod2() throws Exception {
+        String contents = 
+                "class A {\n" +
+                "    public <T> T myMethod(Class<T> claz) {\n" +
+                "        return null\n" +
+                "    }\n" +
+                "    static void main(String[] args) {\n" +
+                "        A a = new A()\n" +
+                "        def val = a.myMethod(String)\n" +
+                "        val.trim()\n" +
+                "    }\n" +
+                "}";
+        
+        int start = contents.lastIndexOf("val");
+        int end = start + "val".length();
+        assertType(contents, start, end, "java.lang.String");
+    }
+
+    // Generic method without object type inference with @CompileStatic
+    public void testMethod3() throws Exception {
+        String contents = 
+                "import groovy.transform.CompileStatic\n" +
+                "class A {\n" +
+                "    public <T> T myMethod(Class<T> claz) {\n" +
+                "        return null\n" +
+                "    }\n" +
+                "    @CompileStatic\n" +
+                "    def m() {\n" +
+                "        def val = myMethod(String)\n" +
+                "        val.trim()\n" +
+                "    }\n" +
+                "}";
+        
+        int start = contents.lastIndexOf("val");
+        int end = start + "val".length();
+        assertType(contents, start, end, "java.lang.String");
+    }
+
+    // Generic method type without object inference without @CompileStatic
+    public void testMethod4() throws Exception {
+        String contents = 
+                "class A {\n" +
+                "    public <T> T myMethod(Class<T> claz) {\n" +
+                "        return null\n" +
+                "    }\n" +
+                "    def m() {\n" +
+                "        def val = myMethod(String)\n" +
+                "        val.trim()\n" +
+                "    }\n" +
+                "}";
+        
+        int start = contents.lastIndexOf("val");
+        int end = start + "val".length();
+        assertType(contents, start, end, "java.lang.String");
+    }
+
     private class ProblemRequestor implements IProblemRequestor {
     	
     	List<IProblem> problems = new ArrayList<IProblem>();


### PR DESCRIPTION
Actually StaticTypeCheckingVisitor is not used as visitor. Only its inferencing mechanism is reused. Unfortunately, inferReturnTypeGenerics method is not public and static (as inferLoopElementType method, for instance). 
So it is reused by subclassing. Actually the class is instantiated with some values as its constructor requires some of parameters should not be null.
But it looks like those values are not actually used during type inference.
