### PR TITLE
GRECLIPSE-1765 Fix to prevent NPE

### DIFF
--- a/base/org.codehaus.groovy23/src/org/codehaus/groovy/control/CompilationUnit.java
+++ b/base/org.codehaus.groovy23/src/org/codehaus/groovy/control/CompilationUnit.java
@@ -875,7 +875,8 @@ public class CompilationUnit extends ProcessingUnit {
             //
             // GRECLIPSE: if there are errors, don't generate code. 
             // code gen can fail unexpectedly if there was an earlier error.
-            if (!source.getErrorCollector().hasErrors()) {
+            // source can be null for class nodes created by StaticTypeCheckingSupport
+            if (source == null || !source.getErrorCollector().hasErrors()) {
             // end
 	            generator.visitClass(classNode);
 	


### PR DESCRIPTION
NPE occured in org.codehaus.groovy.control.CompilationUnit.classgen.new PrimaryClassNodeOperation() {...}.call(SourceUnit, GeneratorContext, ClassNode) method.
That method is called with null source value from org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(PrimaryClassNodeOperation).

In applyToPrimaryClassNodes() method there are iterations over primary class nodes. Some of them can be generated with names like 'Expression$83107cf3$af3b$4037$95e7$0e113106d0af' and without sources.

Those sourceless classes are generated by org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport.evaluateExpression(Expression, CompilerConfiguration).

A few lines above the line where NPE occurred the source value is checked for null, and this checking comes from unpatched CompilationUnit class.

So I think it is normal for 'source' parameter to be null and these null sources should not prevent class generation in PrimaryClassNodeOperation.
