### PR TITLE
GRECLIPSE-1775

### DIFF
--- a/base/org.eclipse.jdt.groovy.core/src/org/eclipse/jdt/groovy/search/TypeInferencingVisitorWithRequestor.java
+++ b/base/org.eclipse.jdt.groovy.core/src/org/eclipse/jdt/groovy/search/TypeInferencingVisitorWithRequestor.java
@@ -1596,7 +1596,9 @@ public class TypeInferencingVisitorWithRequestor extends ClassCodeVisitorSupport
 					handleSimpleExpression(key);
 				}
 				// and visit the value as normal
-				handleSimpleExpression(entry.getValueExpression());
+				entry.getValueExpression().visit(this);
+
+				// handleSimpleExpression(entry.getValueExpression());
 			}
 		}
 		completeExpressionStack.pop();

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test13/in/A.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test13/in/A.groovy
@@ -1,0 +1,17 @@
+package p;
+import groovy.transform.CompileStatic
+
+class MyBean {
+	Class foo
+	public String setBar(Class bar) {
+		foo = bar
+	}
+}
+
+@CompileStatic
+class A {
+	def f = new MyBean()
+	void main() {
+		MyBean b2 = new MyBean(foo: f.foo)
+	}
+}

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test13/out/A.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/RenameField/test13/out/A.groovy
@@ -1,0 +1,17 @@
+package p;
+import groovy.transform.CompileStatic
+
+class MyBean {
+	Class foo
+	public String setBar(Class bar) {
+		foo = bar
+	}
+}
+
+@CompileStatic
+class A {
+	def g = new MyBean()
+	void main() {
+		MyBean b2 = new MyBean(foo: g.foo)
+	}
+}

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/rename/RenameFieldTests.java
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/rename/RenameFieldTests.java
@@ -207,4 +207,7 @@ public class RenameFieldTests extends RefactoringTest {
     public void test12() throws Exception {
     	helper2_0("A", "f", "g", true, false, false, false, false, true);
     }
+    public void test13() throws Exception {
+    	helper2_0("A", "f", "g", true, false, false, false, false, true);
+    }
 }


### PR DESCRIPTION
TypeInferencingVisitorWithRequestor now won't ignore PropertyExpression node's values
