### PR TITLE
GRECLIPSE-1789 Add non default output locations to classpath.

### DIFF
--- a/jdt-patch/e44/org.eclipse.jdt.core/model/org/eclipse/jdt/core/util/CompilerUtils.java
+++ b/jdt-patch/e44/org.eclipse.jdt.core/model/org/eclipse/jdt/core/util/CompilerUtils.java
@@ -269,17 +269,23 @@ public class CompilerUtils {
 					}
 				}
 				accumulatedPathEntries.add(defaultOutputLocation);
-				// GRECLIPSE start
-				// Add output locations which are not default
-				for (IClasspathEntry entry : javaProject.getRawClasspath()) {
-					if (entry.getOutputLocation() != null) {
-						String location = pathToString(entry.getOutputLocation(), project);
-						if (!defaultOutputLocation.equals(location)) {
-							accumulatedPathEntries.add(location);
+//				// GRECLIPSE start
+//				// Add output locations which are not default
+				try {
+					if (isGroovyNaturedProject(project)) {
+						for (IClasspathEntry entry : javaProject.getRawClasspath()) {
+							if (entry.getOutputLocation() != null) {
+								String location = pathToString(entry.getOutputLocation(), project);
+								if (!defaultOutputLocation.equals(location)) {
+									accumulatedPathEntries.add(location);
+								}
+							}
 						}
 					}
+				} catch (CoreException e) {
+					System.err.println("Unexpected error on checking Groovy Nature"); //$NON-NLS-1$
 				}
-				// GRECLIPSE end
+//				// GRECLIPSE end
 				StringBuilder sb = new StringBuilder();
 				Iterator<String> iter = accumulatedPathEntries.iterator();
 				while (iter.hasNext()) {


### PR DESCRIPTION
Actually this fix can be applied to org.eclipse.jdt.groovy.core project, but it seems a bit strange to me, that CompilerUtils adds to classpath default output location, but ignores other output locations, so I guess the correct place is here.
Probably the same fix should be applied to other jdt-patch projects, at least for supporting Groovy 2.3 and traits.
