### PR TITLE
STS-3930 Fix & test

### DIFF
--- a/base-test/org.eclipse.jdt.groovy.core.tests.compiler/src/org/eclipse/jdt/groovy/core/tests/basic/GroovySimpleTest.java
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.compiler/src/org/eclipse/jdt/groovy/core/tests/basic/GroovySimpleTest.java
@@ -11890,6 +11890,24 @@ public class GroovySimpleTest extends AbstractGroovyRegressionTest {
                 "println 'done'"}, "done", augmented, true, null, options, null);
     }
 
+	public void testSts3930() {
+		this.runConformTest(new String[] {
+				"GroovyDemo.groovy",
+				"package demo\n"+
+				"class GroovyDemo {\n" +
+				"    static <T> List someMethod(Class<T> factoryClass, ClassLoader classLoader = GroovyDemo.class.classLoader) {}\n" +
+				"}",
+				"JavaDemo.java",
+				"package demo;\n"+
+				"public class JavaDemo {\n" +
+				"    public static void someMethod() {\n" +
+				"        GroovyDemo.someMethod(JavaDemo.class);\n" +
+				"    }\n" +
+				"}\n",
+				},
+				"");
+	}
+
 	// FIXASC what does this actually mean to groovy?  from GrailsPluginUtils
 //  static Resource[] getPluginXmlMetadata(String pluginsDirPath) {
 //      return getPluginXmlMetadata(pluginsDirPath, DEFAULT_RESOURCE_RESOLVER)


### PR DESCRIPTION
For generic methods with default parameter values type variables and parameter arguments should be the same as it is for all other methods.
