### PR TITLE
Handle Traits code completion NPE

### DIFF
--- a/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/requestor/CompletionNodeFinder.java
+++ b/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/requestor/CompletionNodeFinder.java
@@ -315,20 +315,27 @@ public class CompletionNodeFinder extends ClassCodeVisitorSupport {
         blockStack.pop();
 
         Statement code = node.getCode();
-        visitClassCodeContainer(code);
 
+        /*
+         * Traits have code assigned to null by the TraitASTTransformation. The
+         * transformation creates a helper inner class node that has the
+         * necessary data. Hence skip the rest if code is null
+         */
+        if (code != null) {
+            visitClassCodeContainer(code);
 
-        if (completionOffset < code.getStart() && !isRunMethod(node)) {
-            // probably inside an empty parameters list
-            createContext(null, node, PARAMETER);
+            if (completionOffset < code.getStart() && !isRunMethod(node)) {
+                // probably inside an empty parameters list
+                createContext(null, node, PARAMETER);
+            }
+
+            // if we get here, then it is probably because the block statement
+            // has been swapped with a new one that has not had
+            // its locations set properly
+            code.setStart(node.getStart());
+            code.setEnd(node.getEnd());
+            createContext(code, code, expressionScriptOrStatement(node));
         }
-
-        // if we get here, then it is probably because the block statement
-        // has been swapped with a new one that has not had
-        // its locations set properly
-        code.setStart(node.getStart());
-        code.setEnd(node.getEnd());
-        createContext(code, code, expressionScriptOrStatement(node));
     }
 
     /**


### PR DESCRIPTION
TraitsASTTransformation goes through traits and creates a helper inner class node for each of them and fills it with method node created based on initial class node method nodes. Difference is in #processMethodNode(MethodNode) method. This method also sets the code property of the initial method node to null (hence the NPE in completion assist). The idea behind it i guess is that for the helper inner class node method nodes to have the data.
Code completion visitor gets to the method node and requires method node's code field not to be null. If we add a null check suppport around the code generating the NPE then ideally we should not only avoid throwing NPE, but also fix CA. There is an InnerClassNode helper for a trait along with the initial ClassNode that has the corresponding method nodes with non-null, valid "code" property that will be examined next.
