### PR TITLE
Map#each(Closure) static compile fix for Groovy 2.1.x - 2.3.x + unit test

### DIFF
--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/builder/BasicGroovyBuildTests.java
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/src/org/eclipse/jdt/core/groovy/tests/builder/BasicGroovyBuildTests.java
@@ -1030,6 +1030,37 @@ public class BasicGroovyBuildTests extends GroovierBuilderTests {
 		expectingCompiledClassesV("Foo");
 	}
 	
+	public void testCompileStatic_MapEachClosure() throws Exception {
+		if (GroovyUtils.GROOVY_LEVEL < 20) {
+			return;
+		}
+		IPath projectPath = env.addProject("Project"); //$NON-NLS-1$
+		env.addExternalJars(projectPath, Util.getJavaClassLibs());
+		env.addGroovyJars(projectPath);
+		fullBuild(projectPath);
+		// remove old package fragment root so that names don't collide
+		env.removePackageFragmentRoot(projectPath, ""); //$NON-NLS-1$
+
+		IPath root = env.addPackageFragmentRoot(projectPath, "src"); //$NON-NLS-1$
+		env.setOutputFolder(projectPath, "bin"); //$NON-NLS-1$
+
+		env.addGroovyClass(root, "", "Demo",
+				"@groovy.transform.CompileStatic\n"+
+				"class Demo {\n"+
+			    "	void doit() {\n" +
+			    "		def c = {\n" +
+	            "			Map<String, String> data = [:]\n" +
+	            "			Map<String, Set<String>> otherData = [:];\n" +	 
+	            "			data.each { String k, String v ->\n" +
+	            "		    	def foo = otherData.get(k)\n" +
+	            "			}\n" +
+	        	"		}\n" +
+				"	}\n" +
+				"}\n");
+
+		incrementalBuild(projectPath);
+		expectingNoProblems();
+	}
 
 	public void test1167() throws Exception {
 		IPath projectPath = env.addProject("Project", "1.5"); //$NON-NLS-1$

--- a/base/org.codehaus.groovy21/src/org/codehaus/groovy/ast/ClassNode.java
+++ b/base/org.codehaus.groovy21/src/org/codehaus/groovy/ast/ClassNode.java
@@ -1518,24 +1518,24 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
     }
     
 	// original:
-//    public ClassNode getPlainNodeReference() {
-//        if (ClassHelper.isPrimitiveType(this)) return this;
-//        ClassNode n = new ClassNode(name,modifiers,superClass,null,null);
-//        n.isPrimaryNode = false;
-//        n.setRedirect(redirect());
-//        n.componentType = redirect().getComponentType();
-//        return n;
-//    }
-
     public ClassNode getPlainNodeReference() {
         if (ClassHelper.isPrimitiveType(this)) return this;
-		ClassNode n = new ClassNode(name, modifiers, superClass,
-				getPlainNodeReferencesFor(getInterfaces()), null);
+        ClassNode n = new ClassNode(name,modifiers,superClass,null,null);
         n.isPrimaryNode = false;
-		n.setRedirect(redirect());
+        n.setRedirect(redirect());
         n.componentType = redirect().getComponentType();
         return n;
     }
+
+//    public ClassNode getPlainNodeReference() {
+//        if (ClassHelper.isPrimitiveType(this)) return this;
+//		ClassNode n = new ClassNode(name, modifiers, superClass,
+//				getPlainNodeReferencesFor(getInterfaces()), null);
+//        n.isPrimaryNode = false;
+//		n.setRedirect(redirect());
+//        n.componentType = redirect().getComponentType();
+//        return n;
+//    }
 
 	public ClassNode[] getPlainNodeReferencesFor(ClassNode[] classNodes) {
 		if (classNodes == null) {

--- a/base/org.codehaus.groovy21/src/org/codehaus/groovy/vmplugin/v5/Java5.java
+++ b/base/org.codehaus.groovy21/src/org/codehaus/groovy/vmplugin/v5/Java5.java
@@ -439,7 +439,7 @@ public class Java5 implements VMPlugin {
             front.setRedirect(back);
             return front;
         }
-        return back;//.getPlainNodeReference(); // GRECLIPSE did we remove the getPlain at some point???
+        return back.getPlainNodeReference();
     }
 
     private Parameter[] makeParameters(CompileUnit cu, Type[] types, Class[] cls, Annotation[][] parameterAnnotations) {

--- a/base/org.codehaus.groovy22/src/org/codehaus/groovy/ast/ClassNode.java
+++ b/base/org.codehaus.groovy22/src/org/codehaus/groovy/ast/ClassNode.java
@@ -1530,25 +1530,27 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
     }
     
 // GRECLIPE start
-/*old:
+//old:
     public ClassNode getPlainNodeReference() {
         if (ClassHelper.isPrimitiveType(this)) return this;
-        ClassNode n = new ClassNode(name,modifiers,superClass,null,null);
+        ClassNode n = new ClassNode(name, modifiers, superClass,null,null);
         n.isPrimaryNode = false;
         n.setRedirect(redirect());
-        n.componentType = redirect().getComponentType();
+        if (isArray()) {
+            n.componentType = redirect().getComponentType();
+        } 
         return n;
     }
-new:*/
-    public ClassNode getPlainNodeReference() {
-        if (ClassHelper.isPrimitiveType(this)) return this;
-		ClassNode n = new ClassNode(name, modifiers, superClass,
-				getPlainNodeReferencesFor(getInterfaces()), null);
-        n.isPrimaryNode = false;
-		n.setRedirect(redirect());
-        n.componentType = redirect().getComponentType();
-        return n;
-    }
+// new:
+//    public ClassNode getPlainNodeReference() {
+//        if (ClassHelper.isPrimitiveType(this)) return this;
+//		ClassNode n = new ClassNode(name, modifiers, superClass,
+//				getPlainNodeReferencesFor(getInterfaces()), null);
+//        n.isPrimaryNode = false;
+//		n.setRedirect(redirect());
+//        n.componentType = redirect().getComponentType();
+//        return n;
+//    }
 //end
 
 	public ClassNode[] getPlainNodeReferencesFor(ClassNode[] classNodes) {

--- a/base/org.codehaus.groovy22/src/org/codehaus/groovy/vmplugin/v5/Java5.java
+++ b/base/org.codehaus.groovy22/src/org/codehaus/groovy/vmplugin/v5/Java5.java
@@ -443,7 +443,7 @@ public class Java5 implements VMPlugin {
             front.setRedirect(back);
             return front;
         }
-        return back;//.getPlainNodeReference(); // GRECLIPSE did we remove the getPlain at some point???
+        return back.getPlainNodeReference();
     }
 
     private Parameter[] makeParameters(CompileUnit cu, Type[] types, Class[] cls, Annotation[][] parameterAnnotations) {

--- a/base/org.codehaus.groovy23/src/org/codehaus/groovy/ast/ClassNode.java
+++ b/base/org.codehaus.groovy23/src/org/codehaus/groovy/ast/ClassNode.java
@@ -1556,14 +1556,22 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
     }
 new:*/
     public ClassNode getPlainNodeReference() {
+//        if (ClassHelper.isPrimitiveType(this)) return this;
+//		ClassNode n = new ClassNode(name, modifiers, superClass,
+//				getPlainNodeReferencesFor(getInterfaces()), null);
+//        n.isPrimaryNode = false;
+//		n.setRedirect(redirect());
+//		if (isArray()) {
+//        	n.componentType = redirect().getComponentType();
+//        }
+//        return n;
         if (ClassHelper.isPrimitiveType(this)) return this;
-		ClassNode n = new ClassNode(name, modifiers, superClass,
-				getPlainNodeReferencesFor(getInterfaces()), null);
+        ClassNode n = new ClassNode(name, modifiers, superClass,null,null);
         n.isPrimaryNode = false;
-		n.setRedirect(redirect());
-		if (isArray()) {
-        	n.componentType = redirect().getComponentType();
-        }
+        n.setRedirect(redirect());
+        if (isArray()) {
+            n.componentType = redirect().getComponentType();
+        } 
         return n;
     }
 //end

--- a/base/org.codehaus.groovy23/src/org/codehaus/groovy/vmplugin/v5/Java5.java
+++ b/base/org.codehaus.groovy23/src/org/codehaus/groovy/vmplugin/v5/Java5.java
@@ -463,7 +463,7 @@ public class Java5 implements VMPlugin {
             front.setRedirect(back);
             return front;
         }
-        return back;//.getPlainNodeReference(); // GRECLIPSE did we remove the getPlain at some point???
+        return back.getPlainNodeReference();
     }
 
     private Parameter[] makeParameters(CompileUnit cu, Type[] types, Class[] cls, Annotation[][] parameterAnnotations) {


### PR DESCRIPTION
Problem occurs for Groovy compiler versions starting 2.1. 2.0 didn't have the problem because there was no check for this at the time. There are some tests around DGM methods in Groovy 2.1, so there is an error, but the wording is a bit different. Groovy 2.2 and 2,3 result in the same error
The difference between groovyc compilation and groovy-eclipse compilation is our groovy-eclipse changes to Groovy core.
1) Java5#makeClassNode(...) returns plain node reference rather than just the node.
2) Once the change above is made ClassNode cannot call getInterfaces() from getPlainNodeReference(), because that may cause infinite loop with class node's lazy init. Hence, modified ClassNode#getPlainNodeReference() to match the original code in Groovy core.

I have ran the tests for Groovy 2.1, 2.2 and 2.3 with the fixes and without and the fix doesn't cause any test failures.
Not sure why it's necessary to get transfer interfaces on plain node reference... this modification seem to be done along time ago, perhaps for Groovy 2.0 and up it's not needed anymore.
