### PR TITLE
remove GString style message from GroovyShellLaunchDelegate

### DIFF
--- a/ide/org.codehaus.groovy.eclipse.core/src/org/codehaus/groovy/eclipse/core/launchers/GroovyShellLaunchDelegate.java
+++ b/ide/org.codehaus.groovy.eclipse.core/src/org/codehaus/groovy/eclipse/core/launchers/GroovyShellLaunchDelegate.java
@@ -65,7 +65,7 @@ public class GroovyShellLaunchDelegate extends JavaLaunchDelegate {
             URL jar = resolve(enu.nextElement());
             return jar.getFile();
         } else {
-            throw new CoreException(new Status(Status.ERROR, GroovyCoreActivator.PLUGIN_ID, "Could not find $jarName on the class path.  Please add it manually"));
+            throw new CoreException(new Status(Status.ERROR, GroovyCoreActivator.PLUGIN_ID, "Could not find " + jarName + " on the class path.  Please add it manually"));
         }
     }
 


### PR DESCRIPTION
I think this is a simple typo left over from when the file used to be Groovy.  This came up in an SO [question](http://stackoverflow.com/questions/20646785/ggts-cant-run-groovy-shell) where the user had no idea what `$jarFile` referred to.