### PR TITLE
ImmutableClassNode.enableWriteProtection concurrent modification fix

### DIFF
--- a/base/org.codehaus.groovy23/src/org/codehaus/groovy/ast/ImmutableClassNode.java
+++ b/base/org.codehaus.groovy23/src/org/codehaus/groovy/ast/ImmutableClassNode.java
@@ -80,7 +80,7 @@ class ImmutableClassNode extends ClassNode {
     }
     
     private boolean genericsInitialized = false;
-	private boolean writeProtected = false;
+	private volatile boolean writeProtected = false;
     
     public ImmutableClassNode(Class c) {
         super(c);
@@ -122,13 +122,15 @@ class ImmutableClassNode extends ClassNode {
     	return super.getDeclaredMethods(name);
     }
 
-	private synchronized void enableWriteProtection() {
-		for (Object key : methods.map.keySet()) {
-			List<MethodNode> l = methods.get(key);
-			methods.map.put(key, Collections.unmodifiableList(l));
-		}
-		methods.map = Collections.unmodifiableMap(methods.map);
-		writeProtected = true;
-	}
+    private synchronized void enableWriteProtection() {
+        if (!writeProtected) {
+            for (Object key : methods.map.keySet()) {
+                List<MethodNode> l = methods.get(key);
+                methods.map.put(key, Collections.unmodifiableList(l));
+            }
+            methods.map = Collections.unmodifiableMap(methods.map);
+            writeProtected = true;
+        }
+    }
     
 }

--- a/base/org.codehaus.groovy24/src/org/codehaus/groovy/ast/ImmutableClassNode.java
+++ b/base/org.codehaus.groovy24/src/org/codehaus/groovy/ast/ImmutableClassNode.java
@@ -77,7 +77,7 @@ class ImmutableClassNode extends ClassNode {
     }
 
     private boolean genericsInitialized = false;
-    private boolean writeProtected = false;
+    private volatile boolean writeProtected = false;
 
     public ImmutableClassNode(Class c) {
         super(c);
@@ -120,11 +120,13 @@ class ImmutableClassNode extends ClassNode {
     }
 
     private synchronized void enableWriteProtection() {
-        for (Object key : methods.map.keySet()) {
-            List<MethodNode> l = methods.get(key);
-            methods.map.put(key, Collections.unmodifiableList(l));
+        if (!writeProtected) {
+            for (Object key : methods.map.keySet()) {
+                List<MethodNode> l = methods.get(key);
+                methods.map.put(key, Collections.unmodifiableList(l));
+            }
+            methods.map = Collections.unmodifiableMap(methods.map);
+            writeProtected = true;
         }
-        methods.map = Collections.unmodifiableMap(methods.map);
-        writeProtected = true;
     }
 }


### PR DESCRIPTION
`ImmutableClassNode.enableWriteProtection` concurrent modification fix for https://github.com/groovy/groovy-eclipse/issues/132
