### PR TITLE
Fix extra jar exclusion in CompilerUtils.

### DIFF
--- a/ide/org.codehaus.groovy.eclipse.core/src/org/codehaus/groovy/eclipse/core/compiler/CompilerUtils.java
+++ b/ide/org.codehaus.groovy.eclipse.core/src/org/codehaus/groovy/eclipse/core/compiler/CompilerUtils.java
@@ -231,7 +231,7 @@ public class CompilerUtils {
         List<IPath> jarPaths = new ArrayList<IPath>();
         Bundle groovyBundle = CompilerUtils.getActiveGroovyBundle();
         for (URL jarUrl : Collections.list(groovyBundle.findEntries("lib", "*.jar", false))) {
-            if (!jarUrl.getFile().startsWith("groovy-all") && (!jarUrl.getFile().startsWith("servlet") || includeServlet) &&
+            if (!jarUrl.getFile().contains("groovy-all-") && (!jarUrl.getFile().contains("servlet-") || includeServlet) &&
                     !jarUrl.getFile().endsWith("-javadoc.jar") && !jarUrl.getFile().endsWith("-sources.jar")) {
                 jarPaths.add(toFilePath(jarUrl));
             }


### PR DESCRIPTION
This was broken in 6bc611acafa09a2d3eb289ba5ed7732bf1d0f71e: `jarUrl.getFile()` returns a path like '/lib/groovy-all-2.4.12.jar', so it never startsWith groovy-all.