### PR TITLE
Fix for issue #367: support 3 states of import/qualifier for enum values

### DIFF
--- a/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/completions/ParameterGuesserDelegate.java
+++ b/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/completions/ParameterGuesserDelegate.java
@@ -161,14 +161,14 @@ public class ParameterGuesserDelegate {
             public int getReplacementOffset() {
                 return position.getOffset();
             }
-            /*@Override
+            @Override
             public void setReplacementOffset(int offset) {
-                if (offset > getReplacementOffset()) {
-                    position.setOffset(getReplacementOffset() + (getReplacementLength() - super.getReplacementLength()));
-                    position.setLength(super.getReplacementLength());
+                if (offset > getReplacementOffset() && getReplacementLength() > super.getReplacementLength()) {
+                    offset = getReplacementOffset() + (getReplacementLength() - super.getReplacementLength());
+                    // advance replacement offset to account for inserted qualifier and reset length
+                    position.setOffset(offset); position.setLength(super.getReplacementLength());
                 }
-                super.setReplacementOffset(offset);
-            }*/
+            }
         };
         javaProposal.setProposalInfo(new FieldProposalInfo(invocationContext.getProject(), groovyProposal));
         javaProposal.setTriggerCharacters(triggers);


### PR DESCRIPTION
Preferences > Java > Editor > Content Assist > Insertion
   [ ] "Add import instead of qualified name"
      [ ] "Use static imports (only 1.5 or higher)"