### PR TITLE
Fix for issue #511: highlight name range of static method call

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.tests/src/org/codehaus/groovy/eclipse/test/ui/SemanticHighlightingTests.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.tests/src/org/codehaus/groovy/eclipse/test/ui/SemanticHighlightingTests.groovy
@@ -1130,6 +1130,21 @@ final class SemanticHighlightingTests extends GroovyEclipseTestSuite {
             new HighlightedTypedPosition(contents.lastIndexOf('encode'), 'encode'.length(), STATIC_CALL))
     }
 
+    @Test // https://github.com/groovy/groovy-eclipse/issues/511
+    void testGString5() {
+        String contents = '''\
+            import static java.net.URLEncoder.encode
+            @groovy.transform.CompileStatic
+            class SC {
+              def url = "/${encode('head','UTF-8')}/tail"
+            }
+            '''.stripIndent()
+        assertHighlighting(contents,
+            new HighlightedTypedPosition(contents.indexOf('url'), 3, FIELD),
+            new HighlightedTypedPosition(contents.indexOf('encode'), 'encode'.length(), DEPRECATED),
+            new HighlightedTypedPosition(contents.lastIndexOf('encode'), 'encode'.length(), STATIC_CALL))
+    }
+
     @Test
     void testRegex() {
         String contents = '/fdsfasdfas/'

--- a/ide/org.codehaus.groovy.eclipse.ui/src/org/codehaus/groovy/eclipse/editor/highlighting/SemanticHighlightingReferenceRequestor.java
+++ b/ide/org.codehaus.groovy.eclipse.ui/src/org/codehaus/groovy/eclipse/editor/highlighting/SemanticHighlightingReferenceRequestor.java
@@ -289,7 +289,16 @@ public class SemanticHighlightingReferenceRequestor extends SemanticReferenceReq
             kind = HighlightKind.STATIC_CALL;
         }
 
-        return new HighlightedTypedPosition(expr.getStart(), expr.getLength(), kind);
+        int offset, length;
+        if (expr.getNameEnd() < 1) {
+            offset = expr.getStart();
+            length = expr.getLength();
+        } else {
+            offset = expr.getNameStart();
+            length = expr.getNameEnd() - expr.getNameStart() + 1;
+        }
+
+        return new HighlightedTypedPosition(offset, length, kind);
     }
 
     private HighlightedTypedPosition handleVariableExpression(Parameter expr, VariableScope scope) {


### PR DESCRIPTION
@CompileStatic produces a different AST