### PR TITLE
https://github.com/groovy/groovy-eclipse/issues/613

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/CompletionTestSuite.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/CompletionTestSuite.groovy
@@ -305,6 +305,15 @@ abstract class CompletionTestSuite extends GroovyEclipseTestSuite {
         }
     }
 
+    protected void assertProposalSignature(ICompletionProposal proposal, String expected) {
+        String actual = proposal.getDisplayString()
+        int descrSeparator = actual.indexOf('-')
+        if (descrSeparator != -1) {
+            actual = actual.substring(0, descrSeparator).trim();
+        }
+        assertEquals(expected, actual)
+    }
+
     protected void assertExtendedContextElements(GroovyExtendedCompletionContext context, String signature, String... expectedNames) {
         IJavaElement[] visibleElements = context.getVisibleElements(signature)
         assertEquals("Incorrect number of visible elements\nexpected: " + Arrays.toString(expectedNames) +

--- a/ide-test/org.codehaus.groovy.eclipse.dsl.tests/src/org/codehaus/groovy/eclipse/dsl/tests/DSLNamedArgContentAssistTests.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.dsl.tests/src/org/codehaus/groovy/eclipse/dsl/tests/DSLNamedArgContentAssistTests.groovy
@@ -355,4 +355,54 @@ final class DSLNamedArgContentAssistTests extends CompletionTestSuite {
         createDSL(CLOSURE_DSLD)
         checkProposalApplicationNonType(closureContents, closureContents + '0(first: "", "", {  }, "") {  }', closureContents.length(), 'test0')
     }
+
+    @Test //https://github.com/groovy/groovy-eclipse/issues/613
+    void testProposalSignature1() {
+        setJavaPreference(PreferenceConstants.CODEASSIST_GUESS_METHOD_ARGUMENTS, 'false')
+        GroovyContentAssist.default.preferenceStore.setValue(GroovyContentAssist.CLOSURE_BRACKETS, false)
+        GroovyContentAssist.default.preferenceStore.setValue(GroovyContentAssist.CLOSURE_NOPARENS, false)
+        createDSL '''\
+            contribute(currentType()) {
+              method name: 'bar', type: 'void', namedParams:['named1':float,'named2':double], params: ['reg1':int,'reg2':long,'closure':Closure]
+            }
+            '''.stripIndent()
+
+        String contents = 'foo {  }'
+        ICompletionProposal proposal = checkUniqueProposal(contents, 'foo { ', 'bar', 'bar(named1: named1, named2: named2, reg1, reg2, closure)')
+        assertProposalSignature(proposal, "bar(float named1, double named2, int reg1, long reg2, Closure closure) : void")
+    }
+
+    @Test
+    void testProposalSignature2() {
+        setJavaPreference(PreferenceConstants.CODEASSIST_GUESS_METHOD_ARGUMENTS, 'false')
+        GroovyContentAssist.default.preferenceStore.setValue(GroovyContentAssist.CLOSURE_NOPARENS, false)
+        GroovyContentAssist.getDefault().getPreferenceStore().setValue(GroovyContentAssist.CLOSURE_BRACKETS, 'true')
+        createDSL '''\
+            contribute(currentType()) {
+              method name: 'bar', type: 'void', namedParams:['named1':float,'named2':double], params: ['reg1':int,'reg2':long,'closure':Closure]
+            }
+            '''.stripIndent()
+
+        String contents = 'foo {  }'
+        ICompletionProposal proposal = checkUniqueProposal(contents, 'foo { ', 'bar', 'bar(named1: named1, named2: named2, reg1, reg2, { it })')
+        assertProposalSignature(proposal, "bar(float named1, double named2, int reg1, long reg2, Closure closure) : void")
+    }
+
+    @Test
+    void testProposalSignature3() {
+        setJavaPreference(PreferenceConstants.CODEASSIST_GUESS_METHOD_ARGUMENTS, 'false')
+        GroovyContentAssist.getDefault().getPreferenceStore().setValue(GroovyContentAssist.CLOSURE_BRACKETS, 'true')
+        GroovyContentAssist.getDefault().getPreferenceStore().setValue(GroovyContentAssist.CLOSURE_NOPARENS, 'true')
+        createDSL '''\
+            contribute(currentType()) {
+              method name: 'bar', type: 'void', namedParams:['named1':float,'named2':double], params: ['reg1':int,'reg2':long,'closure':Closure]
+            }
+            '''.stripIndent()
+
+        String contents = 'foo {  }'
+        ICompletionProposal proposal = checkUniqueProposal(contents, 'foo { ', 'bar', 'bar(named1: named1, named2: named2, reg1, reg2) { it }')
+        assertProposalSignature(proposal, "bar(float named1, double named2, int reg1, long reg2, Closure closure) : void")
+    }
+
+
 }

--- a/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/completions/GroovyJavaMethodCompletionProposal.java
+++ b/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/completions/GroovyJavaMethodCompletionProposal.java
@@ -501,8 +501,7 @@ public class GroovyJavaMethodCompletionProposal extends JavaMethodCompletionProp
             fPositions.add(new Position(0));
 
             char[] name = (i < npc ? namedParameterNames[i] : positionalParameterNames[i - npc]);
-            // NOTE: named parameters come after positional parameters in the parameterTypes array
-            char[] type = (i < npc ? parameterTypes[i + positionalParameterNames.length] : parameterTypes[i - npc]);
+            char[] type = parameterTypes[i];
 
             ICompletionProposal[] vals;
             if (guess) {

--- a/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/completions/NamedArgsMethodNode.java
+++ b/ide/org.codehaus.groovy.eclipse.codeassist.completion/src/org/codehaus/groovy/eclipse/codeassist/completions/NamedArgsMethodNode.java
@@ -41,9 +41,13 @@ public class NamedArgsMethodNode extends MethodNode {
         if (optionalParams == null) optionalParams = Parameter.EMPTY_ARRAY;
 
         Parameter[] allParams = new Parameter[params.length + namedParams.length + optionalParams.length];
-        System.arraycopy(params, 0, allParams, 0, params.length);
-        System.arraycopy(namedParams, 0, allParams, params.length, namedParams.length);
-        System.arraycopy(optionalParams, 0, allParams, params.length + namedParams.length, optionalParams.length);
+
+        //https://github.com/groovy/groovy-eclipse/issues/613
+        //named parameters go first, followed by positional params (including trailing closure)
+        System.arraycopy(namedParams, 0, allParams, 0, namedParams.length);
+        System.arraycopy(optionalParams, 0, allParams, namedParams.length, optionalParams.length);
+        System.arraycopy(params, 0, allParams, namedParams.length + optionalParams.length, params.length);
+
         return allParams;
     }
 


### PR DESCRIPTION
3 new tests in DSLNamedArgContentAssistTests will fail before the fix and should pass after.
The tests check the same DSLD under different preference options to cover different code branches in GroovyJavaMethodCompletionProposal