### PR TITLE
fixes of issues 625/626

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/CompletionTestSuite.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/CompletionTestSuite.groovy
@@ -190,6 +190,23 @@ abstract class CompletionTestSuite extends GroovyEclipseTestSuite {
         assertEquals('Completion proposal applied but different results found.', expect, actual)
     }
 
+    /**
+     * Applies the specified completion proposal to the active editor and checks
+     * against the expected replacement, the initial parameter selection,
+     * and the target cursor position after after quitting parameter linked mode.
+     */
+    protected void applyProposalAndCheckCursor(ICompletionProposal proposal, String expected,
+        int expectedSelectionOffset, int expectedSelectionLength = 0, int expectedCursorPosition = expectedSelectionOffset) {
+
+        applyProposalAndCheck(proposal, expected)
+
+        JavaContentAssistInvocationContext context = proposal.@fInvocationContext
+
+        assertEquals("Unexpected selection range offset", expectedSelectionOffset, proposal.getSelection(context.document).x);
+        assertEquals("Unexpected selection range length", expectedSelectionLength, proposal.getSelection(context.document).y);
+        assertEquals("Unexpected cursor position", expectedCursorPosition, proposal.replacementOffset + proposal.computeCursorPosition());
+    }
+
     protected void checkReplacementRegexp(ICompletionProposal[] proposals, String expectedReplacement, int expectedCount) {
         int foundCount = 0
         for (proposal in proposals) {

--- a/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/GroovyLikeCompletionTests.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/GroovyLikeCompletionTests.groovy
@@ -90,7 +90,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
     @Test
     void testMethodWithClosure() {
         ICompletionProposal[] proposals = createProposalsAtOffset(SCRIPTCONTENTS, getIndexOf(SCRIPTCONTENTS, 'any'))
-        checkReplacementString(proposals, 'any { it }', 1)
+        checkReplacementString(proposals, 'any {  }', 1)
     }
 
     @Test
@@ -102,7 +102,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
     @Test
     void testMethodWith2Args() {
         ICompletionProposal[] proposals = createProposalsAtOffset(SCRIPTCONTENTS, getIndexOf(SCRIPTCONTENTS, 'findIndexOf'))
-        checkReplacementRegexp(proposals, /findIndexOf\(\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*\) \{ it \}/, 1)
+        checkReplacementRegexp(proposals, /findIndexOf\(\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*\) \{  \}/, 1)
     }
 
     @Test
@@ -168,7 +168,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
         addGroovySource(SCRIPTCONTENTS, nextUnitName())
 
         String contents = 'new Foo().method2'
-        String expected = 'new Foo().method2(arg) { it }'
+        String expected = 'new Foo().method2(arg) {  }'
         checkProposalApplicationNonType(contents, expected, contents.length(), 'method2')
     }
 
@@ -188,7 +188,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
         addGroovySource(SCRIPTCONTENTS, nextUnitName())
 
         String contents = 'new Foo().method2'
-        String expected = 'new Foo().method2(arg) c1'
+        String expected = 'new Foo().method2(arg) {  }'
         checkProposalApplicationNonType(contents, expected, contents.length(), 'method2')
     }
 
@@ -208,7 +208,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
         addGroovySource(SCRIPTCONTENTS, nextUnitName())
 
         String contents = 'new Foo().method3'
-        String expected = 'new Foo().method3(arg, { it }) { it }'
+        String expected = 'new Foo().method3(arg, { it }) {  }'
         checkProposalApplicationNonType(contents, expected, contents.length(), 'method3')
     }
 
@@ -228,7 +228,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
         addGroovySource(SCRIPTCONTENTS, nextUnitName())
 
         String contents = 'new Foo().method3'
-        String expected = 'new Foo().method3(arg, c1) c2'
+        String expected = 'new Foo().method3(arg, c1) {  }'
         checkProposalApplicationNonType(contents, expected, contents.length(), 'method3')
     }
 
@@ -334,7 +334,7 @@ final class GroovyLikeCompletionTests extends CompletionTestSuite {
     void testNamedArguments3() {
         groovyPrefs.setValue(GroovyContentAssist.NAMED_ARGUMENTS, true)
 
-        checkUniqueProposal((SCRIPTCONTENTS - ~/\s*$/) + '.', 'new Foo().', 'method3', 'method3(arg: arg, c1: { it }) { it }')
+        checkUniqueProposal((SCRIPTCONTENTS - ~/\s*$/) + '.', 'new Foo().', 'method3', 'method3(arg: arg, c1: { it }) {  }')
     }
 
     @Test

--- a/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/TriggerCharacterCompletionTests.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/src/org/codehaus/groovy/eclipse/codeassist/tests/TriggerCharacterCompletionTests.groovy
@@ -91,7 +91,9 @@ final class TriggerCharacterCompletionTests extends CompletionTestSuite {
                 closure << ' '
             }
             if (proposal.toString().contains('Closure')) {
-                closure << 'it'
+                if (!isEnabled(GroovyContentAssist.CLOSURE_NOPARENS)) {
+                    closure << 'it'
+                }
             } else {
                 closure << 'o1'
                 if (isEnabled(FORMATTER_INSERT_SPACE_BEFORE_COMMA_IN_ARRAY_INITIALIZER)) {


### PR DESCRIPTION
Fixes of
https://github.com/groovy/groovy-eclipse/issues/625
https://github.com/groovy/groovy-eclipse/issues/626

When a method being completed has a trailing closure and `CLOSURE_NOPARENS` preference is set, the following behavior is honored:
1) Regardless of `CLOSURE_BRACKETS` setting `true` or `false`, the proposed parameter for the trailing closure is going to be empty code block `{  }` instead of `{ it }` or argument name respectively.
2) Trailing closure parameter does not take part in the parameter switching (the linked mode). 
3) For single-argument methods, the caret automatically moves inside the closure code block rather than to the end of replacement statement
4) For multi-argument methods, quitting the linked mode moves the caret automatically inside the closure code block rather than to the end of replacement statement

Note that behavior stays the same as before:
 - for non-trailing closure parameters
 - when `CLOSURE_NOPARENS` is off
 - when closure completion is triggered by '{' character
