### PR TITLE
Want a way to disable "combining closures with only one statement into one line"

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_Closure_Combine_Disabled.txt
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_Closure_Combine_Disabled.txt
@@ -1,0 +1,33 @@
+###prop
+setPreferences=true
+combineClosures=false
+###src
+"hello".each {
+print it
+}
+5.times {
+param -> print param
+print param }
+6.times { print it
+print it }
+7.times { param ->
+	print param
+	print param
+}
+###exp
+"hello".each {
+	print it
+}
+5.times { param ->
+	print param
+	print param
+}
+6.times {
+	print it
+	print it
+}
+7.times { param ->
+	print param
+	print param
+}
+###end

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/formatter/FormatterPreferencesTests.groovy
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/formatter/FormatterPreferencesTests.groovy
@@ -216,4 +216,22 @@ final class FormatterPreferencesTests extends GroovyEclipseTestSuite {
         formatPrefs = new FormatterPreferences(gunit)
         assert !formatPrefs.isRemoveUnnecessarySemicolons()
     }
+
+    /**
+     * Closure preferences should come from the preferences store used by the Groovy preferences page.
+     */
+    @Test
+    void testClosurePrefs() {
+        FormatterPreferencesPage preferencesPage = new FormatterPreferencesPage()
+        IPreferenceStore groovyPrefs = preferencesPage.getPreferenceStore()
+        assert groovyPrefs.contains(GROOVY_FORMATTER_COMBINE_CLOSURES) : 'Using the wrong preferences store?'
+
+        groovyPrefs.setValue(GROOVY_FORMATTER_COMBINE_CLOSURES, true)
+        FormatterPreferences formatPrefs = new FormatterPreferences(gunit)
+        assert formatPrefs.isCombineClosures()
+
+        groovyPrefs.setValue(GROOVY_FORMATTER_COMBINE_CLOSURES, false)
+        formatPrefs = new FormatterPreferences(gunit)
+        assert !formatPrefs.isCombineClosures()
+    }
 }

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/internal/TestPrefInitializer.java
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/src/org/codehaus/groovy/eclipse/refactoring/test/internal/TestPrefInitializer.java
@@ -107,6 +107,11 @@ public final class TestPrefInitializer {
             pref.setValue(PreferenceConstants.GROOVY_FORMATTER_REMOVE_UNNECESSARY_SEMICOLONS, removeUnnecessarySemicolons);
         }
 
+        String combineClosures = properties.get("combineClosures");
+        if (combineClosures != null) {
+            pref.setValue(PreferenceConstants.GROOVY_FORMATTER_COMBINE_CLOSURES, combineClosures);
+        }
+
         return pref;
     }
 }

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/PreferenceConstants.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/PreferenceConstants.java
@@ -56,6 +56,8 @@ public class PreferenceConstants {
 
     public static final boolean DEFAULT_REMOVE_UNNECESSARY_SEMICOLONS = false;
 
+    public static final boolean DEFAULT_COMBINE_CLOSURES = true;
+
     public static final int DEFAULT_LONG_LIST_LENGTH = 30;
 
     public static final String P_PATH = "pathPreference";
@@ -77,6 +79,8 @@ public class PreferenceConstants {
 
 
     public static final String GROOVY_FORMATTER_REMOVE_UNNECESSARY_SEMICOLONS = "groovy.formatter.remove.unnecessary.semicolons";
+
+    public static final String GROOVY_FORMATTER_COMBINE_CLOSURES = "groovy.formatter.combine.closures";
 
     // Save Actions
     public static final String GROOVY_SAVE_ACTION_REMOVE_UNNECESSARY_SEMICOLONS = "groovy.SaveAction.RemoveUnnecessarySemicolons";

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/FormatterPreferencesOnStore.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/FormatterPreferencesOnStore.java
@@ -17,6 +17,7 @@ package org.codehaus.groovy.eclipse.refactoring.formatter;
 
 import static org.codehaus.groovy.eclipse.refactoring.PreferenceConstants.DEFAULT_BRACES_END;
 import static org.codehaus.groovy.eclipse.refactoring.PreferenceConstants.DEFAULT_BRACES_START;
+import static org.codehaus.groovy.eclipse.refactoring.PreferenceConstants.DEFAULT_COMBINE_CLOSURES;
 import static org.codehaus.groovy.eclipse.refactoring.PreferenceConstants.DEFAULT_INDENT_EMPTY_LINES;
 import static org.codehaus.groovy.eclipse.refactoring.PreferenceConstants.DEFAULT_INDENT_MULTILINE;
 import static org.codehaus.groovy.eclipse.refactoring.PreferenceConstants.DEFAULT_INDENT_SIZE;
@@ -67,6 +68,7 @@ public class FormatterPreferencesOnStore implements IFormatterPreferences {
     private boolean smartPaste;
     private boolean indentEmptyLines;
     private boolean removeUnnecessarySemicolons;
+    private boolean combineClosures;
     private int longListLength;
 
     ////////////////////////////////////////////////////
@@ -155,6 +157,17 @@ public class FormatterPreferencesOnStore implements IFormatterPreferences {
         if (pRemoveUnnecessarySemicolons != null) {
             removeUnnecessarySemicolons = pRemoveUnnecessarySemicolons.equals("true");
         }
+
+        combineClosures = DEFAULT_COMBINE_CLOSURES;
+        String pCombineClosures = preferences.getString(PreferenceConstants.GROOVY_FORMATTER_COMBINE_CLOSURES);
+        if (pCombineClosures != null) {
+            if (pCombineClosures.equals("true")) {
+                combineClosures = true;
+            } else if (pCombineClosures.equals("false")) {
+                combineClosures = false;
+            }
+        }
+
         longListLength = DEFAULT_LONG_LIST_LENGTH;
         int pLongListLength = preferences.getInt(PreferenceConstants.GROOVY_FORMATTER_LONG_LIST_LENGTH);
         if (pLongListLength > 0) {
@@ -210,6 +223,11 @@ public class FormatterPreferencesOnStore implements IFormatterPreferences {
     @Override
     public boolean isRemoveUnnecessarySemicolons() {
         return removeUnnecessarySemicolons;
+    }
+
+    @Override
+    public boolean isCombineClosures() {
+        return combineClosures;
     }
 
     @Override

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyBeautifier.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyBeautifier.java
@@ -108,7 +108,7 @@ public class GroovyBeautifier {
                     replaceNLSWithSpace(edits, posClStart, posParamDelim);
                 }
                 // combine closure with only one statments with less than 5 tokens to one line
-                if (codeblock.getStatements().size() == 1 && (posCLEnd - posClStart) < 10) {
+                if (preferences.isCombineClosures() && codeblock.getStatements().size() == 1 && (posCLEnd - posClStart) < 10) {
                     replaceNLSWithSpace(edits, posParamDelim, posCLEnd);
                     ignoreToken.add(formatter.getTokens().get(posCLEnd));
                 } else {

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/IFormatterPreferences.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/IFormatterPreferences.java
@@ -37,5 +37,7 @@ public interface IFormatterPreferences {
 
     boolean isRemoveUnnecessarySemicolons();
 
+    boolean isCombineClosures();
+
     int getLongListLength();
 }

--- a/ide/org.codehaus.groovy.eclipse.ui/src/org/codehaus/groovy/eclipse/preferences/FormatterPreferenceInitializer.java
+++ b/ide/org.codehaus.groovy.eclipse.ui/src/org/codehaus/groovy/eclipse/preferences/FormatterPreferenceInitializer.java
@@ -43,5 +43,6 @@ public class FormatterPreferenceInitializer extends AbstractPreferenceInitialize
         store.setDefault(PreferenceConstants.GROOVY_FORMATTER_LONG_LIST_LENGTH, PreferenceConstants.DEFAULT_LONG_LIST_LENGTH);
 
         store.setDefault(PreferenceConstants.GROOVY_FORMATTER_REMOVE_UNNECESSARY_SEMICOLONS, false);
+        store.setDefault(PreferenceConstants.GROOVY_FORMATTER_COMBINE_CLOSURES, PreferenceConstants.DEFAULT_COMBINE_CLOSURES);
     }
 }

--- a/ide/org.codehaus.groovy.eclipse.ui/src/org/codehaus/groovy/eclipse/preferences/FormatterPreferencesPage.java
+++ b/ide/org.codehaus.groovy.eclipse.ui/src/org/codehaus/groovy/eclipse/preferences/FormatterPreferencesPage.java
@@ -72,6 +72,9 @@ public class FormatterPreferencesPage extends FieldEditorOverlayPage implements 
         addField(new BooleanFieldEditor(PreferenceConstants.GROOVY_FORMATTER_REMOVE_UNNECESSARY_SEMICOLONS,
                 "Remove unnecessary semicolons", getFieldEditorParent()));
 
+        addField(new BooleanFieldEditor(PreferenceConstants.GROOVY_FORMATTER_COMBINE_CLOSURES,
+                "Combine closures with only one statement to one line", getFieldEditorParent()));
+
         PreferenceLinkArea area = new PreferenceLinkArea(getFieldEditorParent(),
                 SWT.WRAP,
                 "org.eclipse.jdt.ui.preferences.CodeFormatterPreferencePage",


### PR DESCRIPTION
See #721 for a description of the problem and the motivation for the design.

This change implements the design described in #721.

The main part of this change is the new conditional check for `preferences.isCombineClosures()` in `GroovyBeautifier`. This is what disables the behavior in question if the user desires. The rest of this change is focused on allowing the user to control this new preference. I set the default value of the preference to `true` to preserve existing behavior.

I added a new test `Formatter_Test_Closure_Combine_Disabled.txt` to cover the new functionality. This test fails before this change and passes after this change. I also added a new test in `FormatterPreferencesTests`, which also passes. I'm not sure if the latter is sufficient to test the change in `FormatterPreferencesPage` that adds the new checkbox to the UI, so any advice here would be appreciated.