### PR TITLE
URL Cleanup

### DIFF
--- a/extras/groovy-eclipse-batch-builder/maven/pom.xml
+++ b/extras/groovy-eclipse-batch-builder/maven/pom.xml
@@ -15,11 +15,11 @@
   <licenses>
     <license>
       <name>The Eclipse Public License</name>
-      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
     </license>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 

--- a/extras/groovy-eclipse-compiler/pom.xml
+++ b/extras/groovy-eclipse-compiler/pom.xml
@@ -13,7 +13,7 @@
 	<licenses>
 		<license>
 			<name>The Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -40,7 +40,7 @@
 	</issueManagement>
 
 	<scm>
-		<url>http://github.com/groovy/groovy-eclipse.git</url>
+		<url>https://github.com/groovy/groovy-eclipse.git</url>
 		<connection>scm:git://github.com/groovy/groovy-eclipse.git</connection>
 		<developerConnection>scm:git:git@github.com:groovy/groovy-eclipse.git</developerConnection>
 	</scm>

--- a/extras/groovy-eclipse-quickstart/pom.xml
+++ b/extras/groovy-eclipse-quickstart/pom.xml
@@ -7,7 +7,7 @@
 
 	<name>Archetype - groovy-eclipse-quickstart</name>
 	<description>Creates an archetype project that uses the groovy-eclipse-compiler to compile a few Groovy and Java classes.</description>
-	<url>http://groovy.codehaus.org/Eclipse+Plugin</url>
+	<url>https://groovy.codehaus.org/Eclipse+Plugin</url>
 	<packaging>jar</packaging>
 
 	<properties>
@@ -25,7 +25,7 @@
 	<licenses>
 		<license>
 			<name>The Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 			<distribution>repo</distribution>
 		</license> 
 	</licenses> 
@@ -44,16 +44,16 @@
 	</developers>
 	<issueManagement>
 		<system>jira</system>
-		<url>http://jira.codehaus.org/browse/GRECLIPSE</url>
+		<url>https://jira.codehaus.org/browse/GRECLIPSE</url>
 	</issueManagement>
 	<scm>
-		<connection>scm:svn:http://svn.codehaus.org/groovy/eclipse</connection>
+		<connection>scm:svn:https://svn.codehaus.org/groovy/eclipse</connection>
 		<developerConnection>scm:svn:https://svn.codehaus.org/groovy/eclipse</developerConnection>
-		<url>http://svn.codehaus.org/groovy/eclipse</url>
+		<url>https://svn.codehaus.org/groovy/eclipse</url>
 	</scm>
 	<organization>
 		<name>The Codehuas</name>
-		<url>http://codehaus.org</url>
+		<url>https://codehaus.org</url>
 	</organization>
 
 	<build>

--- a/groovy-eclipse.setup
+++ b/groovy-eclipse.setup
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <setup:Project
     xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xmi="https://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
+    xmlns:git="https://www.eclipse.org/oomph/setup/git/1.0"
     xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
     xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
-    xmlns:projects="http://www.eclipse.org/oomph/setup/projects/1.0"
-    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
-    xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
-    xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
+    xmlns:projects="https://www.eclipse.org/oomph/setup/projects/1.0"
+    xmlns:setup="https://www.eclipse.org/oomph/setup/1.0"
+    xmlns:setup.p2="https://www.eclipse.org/oomph/setup/p2/1.0"
+    xmlns:setup.targlets="https://www.eclipse.org/oomph/setup/targlets/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
     xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xsi:schemaLocation="https://www.eclipse.org/oomph/setup/git/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore https://www.eclipse.org/oomph/setup/projects/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore https://www.eclipse.org/oomph/setup/targlets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
     name="Groovy-Eclipse"
     label="Groovy-Eclipse">
   <setupTask
       xsi:type="setup:CompoundTask"
       name="User Preferences">
     <annotation
-        source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
+        source="https://www.eclipse.org/oomph/setup/UserPreferences"/>
     <setupTask
         xsi:type="setup:CompoundTask"
         name="org.codehaus.groovy.eclipse.compilerResolver">
@@ -118,7 +118,7 @@
         name="net.sf.eclipsecs.feature.group"
         optional="true"/>
     <repository
-        url="http://ifedorenko.github.com/m2e-extras"/>
+        url="https://ifedorenko.github.com/m2e-extras"/>
     <repository
         url="https://checkstyle.github.io/eclipse-cs/update"/>
     <description></description>
@@ -168,7 +168,7 @@
       id="git.clone.Groovy-Eclipse"
       remoteURI="groovy/groovy-eclipse">
     <annotation
-        source="http://www.eclipse.org/oomph/setup/InducedChoices">
+        source="https://www.eclipse.org/oomph/setup/InducedChoices">
       <detail
           key="inherit">
         <value>github.remoteURIs</value>

--- a/ide-test/org.codehaus.groovy.alltests/pom.xml
+++ b/ide-test/org.codehaus.groovy.alltests/pom.xml
@@ -20,7 +20,7 @@
 
         <!-- Useful references:
           http://wiki.eclipse.org/Tycho/Packaging_Types#eclipse-test-plugin
-          http://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html
+          https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html
         -->
         <configuration>
           <argLine>-Xmx1G -XX:-OmitStackTraceInFastThrow</argLine>

--- a/jdt-patch/e410/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e410/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e410/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e410/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e410/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e410/org.eclipse.jdt.core/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e410/tests-pom/pom.xml
+++ b/jdt-patch/e410/tests-pom/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation

--- a/jdt-patch/e411/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e411/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e411/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e411/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e411/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e411/org.eclipse.jdt.core/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e411/tests-pom/pom.xml
+++ b/jdt-patch/e411/tests-pom/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e47/tests-pom/pom.xml
+++ b/jdt-patch/e47/tests-pom/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e48/tests-pom/pom.xml
+++ b/jdt-patch/e48/tests-pom/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation

--- a/jdt-patch/e49/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e49/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e49/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e49/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e49/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e49/org.eclipse.jdt.core/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation

--- a/jdt-patch/e49/tests-pom/pom.xml
+++ b/jdt-patch/e49/tests-pom/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://wiki.eclipse.org/Tycho/Packaging_Types (200) could not be migrated:  
   ([https](https://wiki.eclipse.org/Tycho/Packaging_Types) result SSLException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://codehaus.org (UnknownHostException) migrated to:  
  https://codehaus.org ([https](https://codehaus.org) result UnknownHostException).
* http://groovy.codehaus.org/Eclipse+Plugin (UnknownHostException) migrated to:  
  https://groovy.codehaus.org/Eclipse+Plugin ([https](https://groovy.codehaus.org/Eclipse+Plugin) result UnknownHostException).
* http://jira.codehaus.org/browse/GRECLIPSE (UnknownHostException) migrated to:  
  https://jira.codehaus.org/browse/GRECLIPSE ([https](https://jira.codehaus.org/browse/GRECLIPSE) result UnknownHostException).
* http://svn.codehaus.org/groovy/eclipse (UnknownHostException) migrated to:  
  https://svn.codehaus.org/groovy/eclipse ([https](https://svn.codehaus.org/groovy/eclipse) result UnknownHostException).
* http://www.eclipse.org/oomph/setup/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/1.0 ([https](https://www.eclipse.org/oomph/setup/1.0) result 404).
* http://www.eclipse.org/oomph/setup/InducedChoices (404) migrated to:  
  https://www.eclipse.org/oomph/setup/InducedChoices ([https](https://www.eclipse.org/oomph/setup/InducedChoices) result 404).
* http://www.eclipse.org/oomph/setup/UserPreferences (404) migrated to:  
  https://www.eclipse.org/oomph/setup/UserPreferences ([https](https://www.eclipse.org/oomph/setup/UserPreferences) result 404).
* http://www.eclipse.org/oomph/setup/git/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/git/1.0 ([https](https://www.eclipse.org/oomph/setup/git/1.0) result 404).
* http://www.eclipse.org/oomph/setup/p2/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/p2/1.0 ([https](https://www.eclipse.org/oomph/setup/p2/1.0) result 404).
* http://www.eclipse.org/oomph/setup/projects/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/projects/1.0 ([https](https://www.eclipse.org/oomph/setup/projects/1.0) result 404).
* http://www.eclipse.org/oomph/setup/targlets/1.0 (404) migrated to:  
  https://www.eclipse.org/oomph/setup/targlets/1.0 ([https](https://www.eclipse.org/oomph/setup/targlets/1.0) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.eclipse.org/legal/epl-v10.html migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* http://www.eclipse.org/org/documents/edl-v10.php migrated to:  
  https://www.eclipse.org/org/documents/edl-v10.php ([https](https://www.eclipse.org/org/documents/edl-v10.php) result 200).
* http://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html migrated to:  
  https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html ([https](https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html) result 200).
* http://github.com/groovy/groovy-eclipse.git migrated to:  
  https://github.com/groovy/groovy-eclipse.git ([https](https://github.com/groovy/groovy-eclipse.git) result 301).
* http://ifedorenko.github.com/m2e-extras migrated to:  
  https://ifedorenko.github.com/m2e-extras ([https](https://ifedorenko.github.com/m2e-extras) result 301).
* http://www.omg.org/XMI migrated to:  
  https://www.omg.org/XMI ([https](https://www.omg.org/XMI) result 301).

# Ignored
These URLs were intentionally ignored.

* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.eclipse.org/oomph/predicates/1.0
* http://www.eclipse.org/oomph/setup/jdt/1.0
* http://www.eclipse.org/oomph/setup/workingsets/1.0
* http://www.eclipse.org/oomph/workingsets/1.0
* http://www.w3.org/2001/XMLSchema-instance