### PR TITLE
URL Cleanup

### DIFF
--- a/Site-org.codehaus.groovy.eclipse/pom.xml
+++ b/Site-org.codehaus.groovy.eclipse/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../pom.xml</relativePath>

--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/pom.xml
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base-test/org.eclipse.jdt.groovy.core.tests.compiler/pom.xml
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.compiler/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.codehaus.groovy.eclipse.compilerResolver/pom.xml
+++ b/base/org.codehaus.groovy.eclipse.compilerResolver/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.codehaus.groovy24/pom.xml
+++ b/base/org.codehaus.groovy24/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.codehaus.groovy25/pom.xml
+++ b/base/org.codehaus.groovy25/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.codehaus.groovy26/pom.xml
+++ b/base/org.codehaus.groovy26/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.eclipse.jdt.groovy.core/pom.xml
+++ b/base/org.eclipse.jdt.groovy.core/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/extras/Feature-org.codehaus.groovy.m2eclipse/pom.xml
+++ b/extras/Feature-org.codehaus.groovy.m2eclipse/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../pom.xml</relativePath>

--- a/extras/groovy-eclipse-batch-builder/maven/pom.xml
+++ b/extras/groovy-eclipse-batch-builder/maven/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-batch</artifactId>
@@ -15,11 +15,11 @@
   <licenses>
     <license>
       <name>The Eclipse Public License</name>
-      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
     </license>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 

--- a/extras/groovy-eclipse-compiler-tests/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>groovy-eclipse-compiler-tests</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/apt-explicit/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/apt-explicit/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/apt-implicit/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/apt-implicit/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-java/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-java/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-mixed/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-mixed/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#do-nothing</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java0/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java0/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#do-almost-nothing</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java1/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java1/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#use-the-groovy-eclipse-compiler-mojo-for-configuring-source-folders</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java2/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java2/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#use-the-build-helper-maven-plugin</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-standard/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-standard/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/config-script/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/config-script/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/invoke-dynamic/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/invoke-dynamic/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/not-incremental/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/not-incremental/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/project-lombok/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/project-lombok/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/transforms-logging/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/transforms-logging/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler/pom.xml
+++ b/extras/groovy-eclipse-compiler/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.codehaus.groovy</groupId>
@@ -53,7 +53,7 @@
 	<licenses>
 		<license>
 			<name>The Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -67,7 +67,7 @@
 	</issueManagement>
 
 	<scm>
-		<url>http://github.com/groovy/groovy-eclipse.git</url>
+		<url>https://github.com/groovy/groovy-eclipse.git</url>
 		<connection>scm:git://github.com/groovy/groovy-eclipse.git</connection>
 		<developerConnection>scm:git:git@github.com:groovy/groovy-eclipse.git</developerConnection>
 	</scm>

--- a/extras/groovy-eclipse-maven-tests/pom.xml
+++ b/extras/groovy-eclipse-maven-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/extras/groovy-eclipse-quickstart/pom.xml
+++ b/extras/groovy-eclipse-quickstart/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>groovy-eclipse-quickstart</artifactId>
@@ -7,7 +7,7 @@
 
 	<name>Archetype - groovy-eclipse-quickstart</name>
 	<description>Creates an archetype project that uses the groovy-eclipse-compiler to compile a few Groovy and Java classes.</description>
-	<url>http://groovy.codehaus.org/Eclipse+Plugin</url>
+	<url>https://groovy.codehaus.org/Eclipse+Plugin</url>
 	<packaging>jar</packaging>
 
 	<properties>
@@ -25,7 +25,7 @@
 	<licenses>
 		<license>
 			<name>The Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 			<distribution>repo</distribution>
 		</license> 
 	</licenses> 
@@ -44,16 +44,16 @@
 	</developers>
 	<issueManagement>
 		<system>jira</system>
-		<url>http://jira.codehaus.org/browse/GRECLIPSE</url>
+		<url>https://jira.codehaus.org/browse/GRECLIPSE</url>
 	</issueManagement>
 	<scm>
-		<connection>scm:svn:http://svn.codehaus.org/groovy/eclipse</connection>
+		<connection>scm:svn:https://svn.codehaus.org/groovy/eclipse</connection>
 		<developerConnection>scm:svn:https://svn.codehaus.org/groovy/eclipse</developerConnection>
-		<url>http://svn.codehaus.org/groovy/eclipse</url>
+		<url>https://svn.codehaus.org/groovy/eclipse</url>
 	</scm>
 	<organization>
 		<name>The Codehuas</name>
-		<url>http://codehaus.org</url>
+		<url>https://codehaus.org</url>
 	</organization>
 
 	<build>

--- a/extras/groovy-eclipse-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/extras/groovy-eclipse-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<name>${artifactId} Groovy Eclipse Maven Java App</name>

--- a/extras/org.codehaus.groovy.m2eclipse/pom.xml
+++ b/extras/org.codehaus.groovy.m2eclipse/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/groovy-eclipse.setup
+++ b/groovy-eclipse.setup
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <setup:Project
     xmi:version="2.0"
-    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xmi="https://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
+    xmlns:git="https://www.eclipse.org/oomph/setup/git/1.0"
     xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
     xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
-    xmlns:projects="http://www.eclipse.org/oomph/setup/projects/1.0"
-    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
-    xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
-    xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
+    xmlns:projects="https://www.eclipse.org/oomph/setup/projects/1.0"
+    xmlns:setup="https://www.eclipse.org/oomph/setup/1.0"
+    xmlns:setup.p2="https://www.eclipse.org/oomph/setup/p2/1.0"
+    xmlns:setup.targlets="https://www.eclipse.org/oomph/setup/targlets/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
     xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
+    xsi:schemaLocation="https://www.eclipse.org/oomph/setup/git/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/predicates/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore https://www.eclipse.org/oomph/setup/projects/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore https://www.eclipse.org/oomph/setup/targlets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore"
     name="Groovy-Eclipse"
     label="Groovy-Eclipse">
   <setupTask
       xsi:type="setup:CompoundTask"
       name="User Preferences">
     <annotation
-        source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
+        source="https://www.eclipse.org/oomph/setup/UserPreferences"/>
     <setupTask
         xsi:type="setup:CompoundTask"
         name="org.codehaus.groovy.eclipse.compilerResolver">
@@ -112,7 +112,7 @@
         name="net.sf.eclipsecs.feature.group"
         optional="true"/>
     <repository
-        url="http://ifedorenko.github.com/m2e-extras"/>
+        url="https://ifedorenko.github.com/m2e-extras"/>
     <repository
         url="https://checkstyle.github.io/eclipse-cs/update"/>
     <description></description>
@@ -123,7 +123,7 @@
     <requirement
         name="org.codehaus.groovy.m2eclipse.feature.feature.group"/>
     <repository
-        url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.9"/>
+        url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.9"/>
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
@@ -131,7 +131,7 @@
     <requirement
         name="org.codehaus.groovy.m2eclipse.feature.feature.group"/>
     <repository
-        url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.8"/>
+        url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.8"/>
   </setupTask>
   <setupTask
       xsi:type="setup.p2:P2Task"
@@ -139,14 +139,14 @@
     <requirement
         name="org.codehaus.groovy.m2eclipse.feature.feature.group"/>
     <repository
-        url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.7"/>
+        url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.7"/>
   </setupTask>
   <setupTask
       xsi:type="git:GitCloneTask"
       id="git.clone.Groovy-Eclipse"
       remoteURI="groovy/groovy-eclipse">
     <annotation
-        source="http://www.eclipse.org/oomph/setup/InducedChoices">
+        source="https://www.eclipse.org/oomph/setup/InducedChoices">
       <detail
           key="inherit">
         <value>github.remoteURIs</value>
@@ -235,23 +235,23 @@
       <repositoryList
           name="2018-09">
         <repository
-            url="http://download.eclipse.org/releases/2018-09"/>
+            url="https://download.eclipse.org/releases/2018-09"/>
         <repository
-            url="http://download.eclipse.org/eclipse/updates/4.9"/>
+            url="https://download.eclipse.org/eclipse/updates/4.9"/>
       </repositoryList>
       <repositoryList
           name="Photon">
         <repository
-            url="http://download.eclipse.org/releases/photon"/>
+            url="https://download.eclipse.org/releases/photon"/>
         <repository
-            url="http://download.eclipse.org/eclipse/updates/4.8"/>
+            url="https://download.eclipse.org/eclipse/updates/4.8"/>
       </repositoryList>
       <repositoryList
           name="Oxygen">
         <repository
-            url="http://download.eclipse.org/releases/oxygen"/>
+            url="https://download.eclipse.org/releases/oxygen"/>
         <repository
-            url="http://download.eclipse.org/eclipse/updates/4.7"/>
+            url="https://download.eclipse.org/eclipse/updates/4.7"/>
       </repositoryList>
     </targlet>
   </setupTask>

--- a/ide-test/org.codehaus.groovy.alltests/pom.xml
+++ b/ide-test/org.codehaus.groovy.alltests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>
@@ -20,7 +20,7 @@
 
         <!-- Useful references:
           http://wiki.eclipse.org/Tycho/Packaging_Types#eclipse-test-plugin
-          http://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html
+          https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html
         -->
 
         <configuration>

--- a/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.core.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.core.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.dsl.tests/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.dsl.tests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.junit.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.junit.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.quickfix.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.quickfix.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.tests/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.tests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/pom.xml
+++ b/ide-test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy.compilerless.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.compilerless.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy.eclipse.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.eclipse.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy.eclipse.photon/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.eclipse.photon/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy.headless.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.headless.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy24.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy24.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy25.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy25.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy26.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy26.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.ant/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.ant/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.astviews/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.astviews/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.codeassist.completion/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.codeassist.completion/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.codebrowsing/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.codebrowsing/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.core/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.core/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.dsl/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.dsl/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.mining/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.mining/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.quickfix/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.quickfix/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.refactoring/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.ui/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.ui/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/jdt-patch/e47/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e47/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e47/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e47/tests-pom/pom.xml
+++ b/jdt-patch/e47/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e48/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e48/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e48/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e48/tests-pom/pom.xml
+++ b/jdt-patch/e48/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e49/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e49/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e49/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e49/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e49/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e49/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e49/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e49/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e49/tests-pom/pom.xml
+++ b/jdt-patch/e49/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codehaus.groovy.eclipse</groupId>
 	<artifactId>org.codehaus.groovy.eclipse.parent</artifactId>
@@ -116,12 +116,12 @@
 				<repository>
 					<id>2018-09</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/2018-09</url>
+					<url>https://download.eclipse.org/releases/2018-09</url>
 				</repository>
 				<repository>
 					<id>eclipse49</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.9</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.9</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -142,12 +142,12 @@
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/photon</url>
+					<url>https://download.eclipse.org/releases/photon</url>
 				</repository>
 				<repository>
 					<id>eclipse48</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.8</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.8</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -168,12 +168,12 @@
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen</url>
+					<url>https://download.eclipse.org/releases/oxygen</url>
 				</repository>
 				<repository>
 					<id>eclipse47</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.7</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.7</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -264,7 +264,7 @@
 		<repository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 	</repositories>
 
@@ -278,7 +278,7 @@
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/releng/composite-sites/pom.xml
+++ b/releng/composite-sites/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<!-- I don't like how this works, it is terribly long and complicated for basically being just
@@ -24,7 +24,7 @@
 		<pluginRepository>
 			<id>plugins-snapshot-local</id>
 			<name>plugins-snapshot-local</name>
-			<url>http://repo.spring.io/plugins-snapshot-local</url>
+			<url>https://repo.spring.io/plugins-snapshot-local</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -148,7 +148,7 @@
 								<name>Groovy Eclipse Latest Release for Eclipse @item@</name>
 								<target>${project.build.directory}/site/@item@</target>
 								<sites>
-									<param>http://dist.springsource.org/release/GRECLIPSE/${dist.version}/@item@</param>
+									<param>https://dist.springsource.org/release/GRECLIPSE/${dist.version}/@item@</param>
 								</sites>
 							</configuration>
 							</pluginExecutor>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://wiki.eclipse.org/Tycho/Packaging_Types (200) with 1 occurrences could not be migrated:  
   ([https](https://wiki.eclipse.org/Tycho/Packaging_Types) result SSLException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://codehaus.org (UnknownHostException) with 1 occurrences migrated to:  
  https://codehaus.org ([https](https://codehaus.org) result UnknownHostException).
* http://groovy.codehaus.org/Eclipse+Plugin (UnknownHostException) with 1 occurrences migrated to:  
  https://groovy.codehaus.org/Eclipse+Plugin ([https](https://groovy.codehaus.org/Eclipse+Plugin) result UnknownHostException).
* http://jira.codehaus.org/browse/GRECLIPSE (UnknownHostException) with 1 occurrences migrated to:  
  https://jira.codehaus.org/browse/GRECLIPSE ([https](https://jira.codehaus.org/browse/GRECLIPSE) result UnknownHostException).
* http://svn.codehaus.org/groovy/eclipse (UnknownHostException) with 2 occurrences migrated to:  
  https://svn.codehaus.org/groovy/eclipse ([https](https://svn.codehaus.org/groovy/eclipse) result UnknownHostException).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.7 (404) with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.7 ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.7) result 404).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.8 (404) with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.8 ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.8) result 404).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.9 (404) with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.9 ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.9) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 2 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).
* http://www.eclipse.org/oomph/setup/1.0 (404) with 1 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/1.0 ([https](https://www.eclipse.org/oomph/setup/1.0) result 404).
* http://www.eclipse.org/oomph/setup/InducedChoices (404) with 1 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/InducedChoices ([https](https://www.eclipse.org/oomph/setup/InducedChoices) result 404).
* http://www.eclipse.org/oomph/setup/UserPreferences (404) with 1 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/UserPreferences ([https](https://www.eclipse.org/oomph/setup/UserPreferences) result 404).
* http://www.eclipse.org/oomph/setup/git/1.0 (404) with 2 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/git/1.0 ([https](https://www.eclipse.org/oomph/setup/git/1.0) result 404).
* http://www.eclipse.org/oomph/setup/p2/1.0 (404) with 1 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/p2/1.0 ([https](https://www.eclipse.org/oomph/setup/p2/1.0) result 404).
* http://www.eclipse.org/oomph/setup/projects/1.0 (404) with 2 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/projects/1.0 ([https](https://www.eclipse.org/oomph/setup/projects/1.0) result 404).
* http://www.eclipse.org/oomph/setup/targlets/1.0 (404) with 2 occurrences migrated to:  
  https://www.eclipse.org/oomph/setup/targlets/1.0 ([https](https://www.eclipse.org/oomph/setup/targlets/1.0) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dist.springsource.org/release/GRECLIPSE/ with 1 occurrences migrated to:  
  https://dist.springsource.org/release/GRECLIPSE/ ([https](https://dist.springsource.org/release/GRECLIPSE/) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore with 1 occurrences migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore with 1 occurrences migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore with 1 occurrences migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore with 1 occurrences migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore) result 200).
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore with 1 occurrences migrated to:  
  https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore ([https](https://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/WorkingSets.ecore) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 58 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.eclipse.org/legal/epl-v10.html with 3 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* http://www.eclipse.org/org/documents/edl-v10.php with 12 occurrences migrated to:  
  https://www.eclipse.org/org/documents/edl-v10.php ([https](https://www.eclipse.org/org/documents/edl-v10.php) result 200).
* http://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html with 1 occurrences migrated to:  
  https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html ([https](https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html) result 200).
* http://download.eclipse.org/eclipse/updates/4.7 with 2 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.7 ([https](https://download.eclipse.org/eclipse/updates/4.7) result 301).
* http://download.eclipse.org/eclipse/updates/4.8 with 2 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.8 ([https](https://download.eclipse.org/eclipse/updates/4.8) result 301).
* http://download.eclipse.org/eclipse/updates/4.9 with 2 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.9 ([https](https://download.eclipse.org/eclipse/updates/4.9) result 301).
* http://download.eclipse.org/releases/2018-09 with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/2018-09 ([https](https://download.eclipse.org/releases/2018-09) result 301).
* http://download.eclipse.org/releases/oxygen with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/oxygen ([https](https://download.eclipse.org/releases/oxygen) result 301).
* http://download.eclipse.org/releases/photon with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/photon ([https](https://download.eclipse.org/releases/photon) result 301).
* http://github.com/groovy/groovy-eclipse.git with 1 occurrences migrated to:  
  https://github.com/groovy/groovy-eclipse.git ([https](https://github.com/groovy/groovy-eclipse.git) result 301).
* http://ifedorenko.github.com/m2e-extras with 1 occurrences migrated to:  
  https://ifedorenko.github.com/m2e-extras ([https](https://ifedorenko.github.com/m2e-extras) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 16 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.omg.org/XMI with 1 occurrences migrated to:  
  https://www.omg.org/XMI ([https](https://www.omg.org/XMI) result 301).
* http://repo.spring.io/plugins-snapshot-local with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-snapshot-local ([https](https://repo.spring.io/plugins-snapshot-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore with 1 occurrences
* http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 148 occurrences
* http://www.eclipse.org/oomph/predicates/1.0 with 2 occurrences
* http://www.eclipse.org/oomph/setup/jdt/1.0 with 2 occurrences
* http://www.eclipse.org/oomph/setup/workingsets/1.0 with 2 occurrences
* http://www.eclipse.org/oomph/workingsets/1.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 75 occurrences