### PR TITLE
URL Cleanup

### DIFF
--- a/Site-org.codehaus.groovy.eclipse/pom.xml
+++ b/Site-org.codehaus.groovy.eclipse/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../pom.xml</relativePath>

--- a/base-test/org.eclipse.jdt.groovy.core.tests.builder/pom.xml
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.builder/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base-test/org.eclipse.jdt.groovy.core.tests.compiler/pom.xml
+++ b/base-test/org.eclipse.jdt.groovy.core.tests.compiler/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.codehaus.groovy.eclipse.compilerResolver/pom.xml
+++ b/base/org.codehaus.groovy.eclipse.compilerResolver/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.codehaus.groovy18/pom.xml
+++ b/base/org.codehaus.groovy18/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <!--  here:   groovy-eclipse/base/org.codehaus.groovy18/pom.xml  -->

--- a/base/org.codehaus.groovy20/pom.xml
+++ b/base/org.codehaus.groovy20/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <!--  here:   groovy-eclipse/base/org.codehaus.groovy20/pom.xml  -->

--- a/base/org.codehaus.groovy21/pom.xml
+++ b/base/org.codehaus.groovy21/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <!--  here:   groovy-eclipse/base/org.codehaus.groovy21/pom.xml  -->

--- a/base/org.codehaus.groovy22/pom.xml
+++ b/base/org.codehaus.groovy22/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <!--  here:   groovy-eclipse/base/org.codehaus.groovy22/pom.xml  -->

--- a/base/org.codehaus.groovy23/pom.xml
+++ b/base/org.codehaus.groovy23/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <!--  here:   groovy-eclipse/base/org.codehaus.groovy23/pom.xml  -->

--- a/base/org.codehaus.groovy24/pom.xml
+++ b/base/org.codehaus.groovy24/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <!--  here:   groovy-eclipse/base/org.codehaus.groovy24/pom.xml  -->

--- a/base/org.codehaus.groovy25/pom.xml
+++ b/base/org.codehaus.groovy25/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/base/org.eclipse.jdt.groovy.core/pom.xml
+++ b/base/org.eclipse.jdt.groovy.core/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/extras/Feature-org.codehaus.groovy.m2eclipse/category.xml
+++ b/extras/Feature-org.codehaus.groovy.m2eclipse/category.xml
@@ -14,7 +14,7 @@
          Optional Maven (M2Eclipse) integration for Groovy-Eclipse.  These features are targetting the
          1.0 version of M2Eclipse and will not install against earlier versions.  For that, you must use a
          different update site:
-         http://dist.codehaus.org/groovy/distributions/greclipse/groovy-m2eclipse/
+         https://dist.codehaus.org/groovy/distributions/greclipse/groovy-m2eclipse/
       </description>
    </category-def>
 </site>

--- a/extras/Feature-org.codehaus.groovy.m2eclipse/pom.xml
+++ b/extras/Feature-org.codehaus.groovy.m2eclipse/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../pom.xml</relativePath>

--- a/extras/catalog.xml
+++ b/extras/catalog.xml
@@ -13,7 +13,7 @@
       <name>Groovy-Eclipse</name>
       <provider>the Codehaus</provider>
       <p2>
-        <repositoryUrl>http://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2</repositoryUrl>
+        <repositoryUrl>https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2</repositoryUrl>
         <iuId>org.codehaus.groovy.m2eclipse.feature.group</iuId>
         <lifecycleMappingIU>
           <iuId>org.codehaus.groovy.m2eclipse</iuId>
@@ -21,7 +21,7 @@
       </p2>
       <overview>
         <summary>Maven Integration for Grooovy-Eclipse</summary>
-        <url>http://docs.codehaus.org/display/GROOVY/Groovy-Eclipse+compiler+plugin+for+Maven</url>
+        <url>https://docs.codehaus.org/display/GROOVY/Groovy-Eclipse+compiler+plugin+for+Maven</url>
       </overview>
     </catalogItem>  
   </catalogItems>

--- a/extras/groovy-eclipse-batch-builder/maven/build-maven.xml
+++ b/extras/groovy-eclipse-batch-builder/maven/build-maven.xml
@@ -32,9 +32,9 @@
         <!-- Commented out, no longer using webdav to deploy.
              Use the simple http install provider that seems to work well and we can
              use the urls described here
-             http://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide#CodehausMavenRepositoryUsageGuide-3.MavenRepositories
+             https://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide#CodehausMavenRepositoryUsageGuide-3.MavenRepositories
              together with settings.xml file to provide credentials as described here:
-             http://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide#CodehausMavenRepositoryUsageGuide-6.POMandsettingsconfig -->
+             https://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide#CodehausMavenRepositoryUsageGuide-6.POMandsettingsconfig -->
     </target>
 
     <target name="-fake.jar">

--- a/extras/groovy-eclipse-batch-builder/maven/pom.xml
+++ b/extras/groovy-eclipse-batch-builder/maven/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-batch</artifactId>
@@ -15,7 +15,7 @@
   <licenses>
     <license>
       <name>The Eclipse Public License</name>
-      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+      <url>https://www.eclipse.org/legal/epl-v10.html</url>
     </license>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/extras/groovy-eclipse-compiler-tests/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>groovy-eclipse-compiler-tests</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/apt-explicit/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/apt-explicit/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/apt-implicit/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/apt-implicit/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-java/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-java/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-mixed/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-mixed/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#do-nothing</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java0/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java0/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#do-almost-nothing</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java1/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java1/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#use-the-groovy-eclipse-compiler-mojo-for-configuring-source-folders</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java2/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-no-java2/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <url>https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-Maven-plugin#use-the-build-helper-maven-plugin</url>

--- a/extras/groovy-eclipse-compiler-tests/src/it/basic-standard/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/basic-standard/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/config-script/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/config-script/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/invoke-dynamic/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/invoke-dynamic/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/not-incremental/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/not-incremental/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/project-lombok/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/project-lombok/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler-tests/src/it/settings.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/settings.xml
@@ -1,4 +1,4 @@
-<settings xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+<settings xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
 	<!-- The test builds will use a sandbox maven local in their build directory.
 		As a consequence test builds won't be able to resolve artifacts installed
 		in our own *real* local repo. To be able to install locally and test before

--- a/extras/groovy-eclipse-compiler-tests/src/it/transforms-logging/pom.xml
+++ b/extras/groovy-eclipse-compiler-tests/src/it/transforms-logging/pom.xml
@@ -2,7 +2,7 @@
  xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                     http://maven.apache.org/maven-v4_0_0.xsd">
+                     https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>groovy-eclipse-maven-test</artifactId>

--- a/extras/groovy-eclipse-compiler/pom.xml
+++ b/extras/groovy-eclipse-compiler/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.codehaus.groovy</groupId>
@@ -53,7 +53,7 @@
 	<licenses>
 		<license>
 			<name>The Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -67,7 +67,7 @@
 	</issueManagement>
 
 	<scm>
-		<url>http://github.com/groovy/groovy-eclipse.git</url>
+		<url>https://github.com/groovy/groovy-eclipse.git</url>
 		<connection>scm:git://github.com/groovy/groovy-eclipse.git</connection>
 		<developerConnection>scm:git:git@github.com:groovy/groovy-eclipse.git</developerConnection>
 	</scm>

--- a/extras/groovy-eclipse-maven-tests/pom.xml
+++ b/extras/groovy-eclipse-maven-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/extras/groovy-eclipse-quickstart/pom.xml
+++ b/extras/groovy-eclipse-quickstart/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.codehaus.groovy</groupId>
   <artifactId>groovy-eclipse-quickstart</artifactId>
   <version>2.5.2-SNAPSHOT</version>
   <name>Archetype - groovy-eclipse-quickstart</name>
   <description>Creates an archetype project that uses the groovy-eclipse-compiler to compile a few Groovy and Java classes.</description>
-	<url>http://groovy.codehaus.org/Eclipse+Plugin</url>
+	<url>https://groovy.codehaus.org/Eclipse+Plugin</url>
 	<packaging>jar</packaging>
 
 	<properties>
@@ -22,7 +22,7 @@
 	<licenses>
 		<license>
 			<name>The Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 			<distribution>repo</distribution>
 		</license> 
 	</licenses> 
@@ -41,16 +41,16 @@
 	</developers>
 	<issueManagement>
 		<system>jira</system>
-		<url>http://jira.codehaus.org/browse/GRECLIPSE</url>
+		<url>https://jira.codehaus.org/browse/GRECLIPSE</url>
 	</issueManagement>
 	<scm>
-		<connection>scm:svn:http://svn.codehaus.org/groovy/eclipse</connection>
+		<connection>scm:svn:https://svn.codehaus.org/groovy/eclipse</connection>
 		<developerConnection>scm:svn:https://svn.codehaus.org/groovy/eclipse</developerConnection>
-		<url>http://svn.codehaus.org/groovy/eclipse</url>
+		<url>https://svn.codehaus.org/groovy/eclipse</url>
 	</scm>
 	<organization>
 		<name>The Codehuas</name>
-		<url>http://codehaus.org</url>
+		<url>https://codehaus.org</url>
 	</organization>
 
 	<build>

--- a/extras/groovy-eclipse-quickstart/src/main/resources/META-INF/maven/archetype.xml
+++ b/extras/groovy-eclipse-quickstart/src/main/resources/META-INF/maven/archetype.xml
@@ -1,5 +1,5 @@
 <archetype xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0 http://maven.apache.org/xsd/archetype-1.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0 https://maven.apache.org/xsd/archetype-1.0.0.xsd">
   <id>groovy-eclipse-quickstart</id>
   <sources>
 	<source>src/main/java/JavaHello.java</source>

--- a/extras/groovy-eclipse-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/extras/groovy-eclipse-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>

--- a/extras/org.codehaus.groovy.m2eclipse/pom.xml
+++ b/extras/org.codehaus.groovy.m2eclipse/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide-test/Feature-org.codehaus.groovy.alltests.feature/feature.xml
+++ b/ide-test/Feature-org.codehaus.groovy.alltests.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
    
     Contributors:
         Andrew Eisenberg - modified for Groovy Eclipse 2.0

--- a/ide-test/Feature-org.codehaus.groovy.alltests.feature/pom.xml
+++ b/ide-test/Feature-org.codehaus.groovy.alltests.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.alltests/pom.xml
+++ b/ide-test/org.codehaus.groovy.alltests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>
@@ -20,7 +20,7 @@
 
         <!-- Useful references:
           http://wiki.eclipse.org/Tycho/Packaging_Types#eclipse-test-plugin
-          http://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html
+          https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html
         -->
 
         <configuration>

--- a/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.codeassist.completion.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.codebrowsing.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.core.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.core.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.dsl.tests/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.dsl.tests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.junit.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.junit.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.quickfix.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.quickfix.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/org.codehaus.groovy.eclipse.tests/pom.xml
+++ b/ide-test/org.codehaus.groovy.eclipse.tests/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide-test/pom.xml
+++ b/ide-test/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../pom.xml</relativePath>

--- a/ide/Feature org.codehaus.groovy.eclipse.sdk/feature.xml
+++ b/ide/Feature org.codehaus.groovy.eclipse.sdk/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
    
     Contributors:
         Andrew Eisenberg - modified for Groovy Eclipse 2.0

--- a/ide/Feature-org.codehaus.groovy.compilerless.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy.compilerless.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
    
     Contributors:
         Andrew Eisenberg - modified for Groovy Eclipse 2.0

--- a/ide/Feature-org.codehaus.groovy.compilerless.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.compilerless.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy.eclipse.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.eclipse.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy.headless.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy.headless.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
    
     Contributors:
         Andrew Eisenberg - modified for Groovy Eclipse 2.0

--- a/ide/Feature-org.codehaus.groovy.headless.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy.headless.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy18.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy18.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
  -->
 <feature
       id="org.codehaus.groovy18.feature"

--- a/ide/Feature-org.codehaus.groovy18.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy18.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy20.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy20.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
  -->
 <feature
       id="org.codehaus.groovy20.feature"

--- a/ide/Feature-org.codehaus.groovy20.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy20.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy21.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy21.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
  -->
 <feature
       id="org.codehaus.groovy21.feature"

--- a/ide/Feature-org.codehaus.groovy21.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy21.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy22.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy22.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
  -->
 <feature
       id="org.codehaus.groovy22.feature"

--- a/ide/Feature-org.codehaus.groovy22.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy22.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy23.feature/feature.xml
+++ b/ide/Feature-org.codehaus.groovy23.feature/feature.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
  -->
 <feature
       id="org.codehaus.groovy23.feature"

--- a/ide/Feature-org.codehaus.groovy23.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy23.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy24.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy24.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../../pom.xml</relativePath>

--- a/ide/Feature-org.codehaus.groovy25.feature/pom.xml
+++ b/ide/Feature-org.codehaus.groovy25.feature/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.ant/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.ant/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.astviews/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.astviews/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.codeassist.completion/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.codeassist.completion/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.codebrowsing/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.codebrowsing/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.core/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.core/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.dsl/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.dsl/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.pluginbuilder/build-files/automatedTests/run-tests.xml
+++ b/ide/org.codehaus.groovy.eclipse.pluginbuilder/build-files/automatedTests/run-tests.xml
@@ -3,7 +3,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
    
     Contributors:
         Unattributed        - Initial API and implementation

--- a/ide/org.codehaus.groovy.eclipse.pluginbuilder/build-files/customTargets.xml
+++ b/ide/org.codehaus.groovy.eclipse.pluginbuilder/build-files/customTargets.xml
@@ -228,7 +228,7 @@
 
 		<!-- fix feature patch version -->
 		<!-- Ensure that feature patch can be installed on multiple versions of Eclipse -->
-		<!-- See http://aniefer.blogspot.com/2009/06/patching-features-part-2.html -->
+		<!-- See https://aniefer.blogspot.com/2009/06/patching-features-part-2.html -->
 		<replace file="${updateSiteDir}/content.xml" summary="yes" token="${orig.jdt.feature.version.range}" value="${new.jdt.feature.version.range}" />
 
 		<echo message="Replace in file ${updateSiteDir}/content.xml attempted on tokens:" />

--- a/ide/org.codehaus.groovy.eclipse.pluginbuilder/build-files/get-dependencies.xml
+++ b/ide/org.codehaus.groovy.eclipse.pluginbuilder/build-files/get-dependencies.xml
@@ -3,7 +3,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
    
     Contributors:
          Tasktop Technologies - initial API and implementation
@@ -11,7 +11,7 @@
  -->
 <project name="Download files and provide provisioning for existing eclipse installatins">
 	
-	<property name="m2e-update-site" value="http://download.eclipse.org/releases/indigo"/>
+	<property name="m2e-update-site" value="https://download.eclipse.org/releases/indigo"/>
 
 	<macrodef name="install-feature" description="Install a feature into a given Eclipse">
 		<attribute name="eclipse.loc" />

--- a/ide/org.codehaus.groovy.eclipse.pluginbuilder/build.xml
+++ b/ide/org.codehaus.groovy.eclipse.pluginbuilder/build.xml
@@ -149,7 +149,7 @@
 		<install-feature eclipse.loc="${target.eclipse.dir}/eclipse" feature.id="org.eclipse.wst.xml_core.feature" updatesite.url="${eclipse.update.site}" />
 		<install-feature eclipse.loc="${target.eclipse.dir}/eclipse" feature.id="org.eclipse.wst.xml_ui.feature" updatesite.url="${eclipse.update.site}" />
 		<install-feature eclipse.loc="${target.eclipse.dir}/eclipse" feature.id="org.eclipse.equinox.p2.discovery.feature" updatesite.url="${eclipse.update.site}" />
-		<install-feature eclipse.loc="${target.eclipse.dir}/eclipse" feature.id="org.eclipse.epp.usagedata.feature" updatesite.url="http://download.eclipse.org/technology/epp/updates/1.0" />
+		<install-feature eclipse.loc="${target.eclipse.dir}/eclipse" feature.id="org.eclipse.epp.usagedata.feature" updatesite.url="https://download.eclipse.org/technology/epp/updates/1.0" />
 		<install-feature eclipse.loc="${target.eclipse.dir}/eclipse" feature.id="org.eclipse.m2e.feature" updatesite.url="${m2e-update-site}" />
 	</target>
 

--- a/ide/org.codehaus.groovy.eclipse.quickfix/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.quickfix/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.refactoring/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse.ui/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse.ui/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/ide/org.codehaus.groovy.eclipse/pom.xml
+++ b/ide/org.codehaus.groovy.eclipse/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../pom.xml</relativePath>

--- a/jdt-patch/e37/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e37/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e37/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e37/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core.tests.builder/test.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e37/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -3,7 +3,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/pom.xml
@@ -3,14 +3,14 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e37/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e37/tests-pom/pom.xml
+++ b/jdt-patch/e37/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e42/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e42/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e42/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e42/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e42/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -3,7 +3,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/pom.xml
@@ -3,14 +3,14 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e42/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e42/tests-pom/pom.xml
+++ b/jdt-patch/e42/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e43/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e43/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e43/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e43/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e43/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -3,7 +3,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/pom.xml
@@ -3,14 +3,14 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e43/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43/tests-pom/pom.xml
+++ b/jdt-patch/e43/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e43j8/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e43j8/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e43j8/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e43j8/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e43j8/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/pom-ORIGINAL.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/pom-ORIGINAL.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>eclipse.jdt.core</artifactId>

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/pom-custom-packaging.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/pom-custom-packaging.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../pom.xml</relativePath>

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/pom.xml
@@ -3,14 +3,14 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e43j8/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e43j8/tests-pom/pom.xml
+++ b/jdt-patch/e43j8/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e44/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e44/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e44/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e44/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e44/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/pom-ORIGINAL.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/pom-ORIGINAL.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>eclipse.jdt.core</artifactId>

--- a/jdt-patch/e44/org.eclipse.jdt.core/pom-custom-packaging.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/pom-custom-packaging.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../pom.xml</relativePath>

--- a/jdt-patch/e44/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e44/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e44/tests-pom/pom.xml
+++ b/jdt-patch/e44/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e45/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e45/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e45/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e45/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e45/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/pom-ORIGINAL.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/pom-ORIGINAL.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>eclipse.jdt.core</artifactId>

--- a/jdt-patch/e45/org.eclipse.jdt.core/pom-custom-packaging.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/pom-custom-packaging.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../pom.xml</relativePath>

--- a/jdt-patch/e45/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e45/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e45/tests-pom/pom.xml
+++ b/jdt-patch/e45/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e46/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e46/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e46/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e46/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e46/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/pom-ORIGINAL.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/pom-ORIGINAL.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>eclipse.jdt.core</artifactId>

--- a/jdt-patch/e46/org.eclipse.jdt.core/pom-custom-packaging.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/pom-custom-packaging.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
   	<relativePath>../pom.xml</relativePath>

--- a/jdt-patch/e46/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e46/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e46/tests-pom/pom.xml
+++ b/jdt-patch/e46/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e47/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e47/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e47/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e47/tests-pom/pom.xml
+++ b/jdt-patch/e47/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e48/Feature-org.codehaus.groovy.jdt.patch/pom.xml
+++ b/jdt-patch/e48/Feature-org.codehaus.groovy.jdt.patch/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/plugin.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/test.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.builder/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
 
   Contributors:
      Igor Fedorenko - initial implementation
      Mickael Istria (Red Hat Inc.) - 416912: tycho-surefire-plugin configuration
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>eclipse.jdt.core</groupId>

--- a/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/component.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/component.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/customBuildCallbacks.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/customBuildCallbacks.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/plugin.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/pom.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/pom.xml
@@ -4,13 +4,13 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      Igor Fedorenko - initial implementation
      Kris De Volder - adapted for greclipse build
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/antadapter/plugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
       EclipseSource Inc. - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/build.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/build.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/build_ecj.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/build_ecj.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ecj.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ecj.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac2.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac2.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac2_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/export-ejavac_linux.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/exportplugin.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/exportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/ikvm_script.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/ikvm_script.xml
@@ -4,7 +4,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/org.eclipse.jdt.core/scripts/oldexportplugin.xml
+++ b/jdt-patch/e48/org.eclipse.jdt.core/scripts/oldexportplugin.xml
@@ -5,7 +5,7 @@
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+    https://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
         IBM Corporation - initial API and implementation

--- a/jdt-patch/e48/tests-pom/pom.xml
+++ b/jdt-patch/e48/tests-pom/pom.xml
@@ -4,12 +4,12 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/org/documents/edl-v10.php
+  https://www.eclipse.org/org/documents/edl-v10.php
  
   Contributors:
      IBM Corporation - initial API and implementation
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <relativePath>../../../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codehaus.groovy.eclipse</groupId>
 	<artifactId>org.codehaus.groovy.eclipse.parent</artifactId>
@@ -123,17 +123,17 @@
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/photon</url>
+					<url>https://download.eclipse.org/releases/photon</url>
 				</repository>
 				<repository>
 					<id>eclipse48</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.8</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.8</url>
 				</repository>
 				<repository>
 					<id>eclipse48-milestones</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.8milestones</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.8milestones</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -154,12 +154,12 @@
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/201712201001</url>
+					<url>https://download.eclipse.org/releases/oxygen/201712201001</url>
 				</repository>
 				<repository>
 					<id>eclipse47</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -180,12 +180,12 @@
 				<repository>
 					<id>neon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/neon</url>
+					<url>https://download.eclipse.org/releases/neon</url>
 				</repository>
 				<repository>
 					<id>eclipse46</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.6</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.6</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -206,12 +206,12 @@
 				<repository>
 					<id>mars</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/mars</url>
+					<url>https://download.eclipse.org/releases/mars</url>
 				</repository>
 				<repository>
 					<id>eclipse45</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.5</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.5</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -232,12 +232,12 @@
 				<repository>
 					<id>luna</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/luna</url>
+					<url>https://download.eclipse.org/releases/luna</url>
 				</repository>
 				<repository>
 					<id>eclipse44</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.4</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.4</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -258,17 +258,17 @@
 				<repository>
 					<id>kepler</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/kepler</url>
+					<url>https://download.eclipse.org/releases/kepler</url>
 				</repository>
 				<repository>
 					<id>eclipse43</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.3</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.3</url>
 				</repository>
 				<repository>
 					<id>eclipse43j8</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.3-P-builds/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.3-P-builds/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -289,12 +289,12 @@
 				<repository>
 					<id>kepler</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/kepler</url>
+					<url>https://download.eclipse.org/releases/kepler</url>
 				</repository>
 				<repository>
 					<id>eclipse43</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.3</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.3</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -315,12 +315,12 @@
 				<repository>
 					<id>juno</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/juno</url>
+					<url>https://download.eclipse.org/releases/juno</url>
 				</repository>
 				<repository>
 					<id>eclipse42</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.2</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.2</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -341,12 +341,12 @@
 				<repository>
 					<id>indigo</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/indigo</url>
+					<url>https://download.eclipse.org/releases/indigo</url>
 				</repository>
 				<repository>
 					<id>eclipse37</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/3.7</url>
+					<url>https://download.eclipse.org/eclipse/updates/3.7</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -444,7 +444,7 @@
 		<repository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 	</repositories>
 
@@ -453,7 +453,7 @@
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/releng/composite-sites/pom.xml
+++ b/releng/composite-sites/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<!-- I don't like how this works, it is terribly long and complicated for basically being just
@@ -24,7 +24,7 @@
 		<pluginRepository>
 			<id>plugins-snapshot-local</id>
 			<name>plugins-snapshot-local</name>
-			<url>http://repo.spring.io/plugins-snapshot-local</url>
+			<url>https://repo.spring.io/plugins-snapshot-local</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -154,7 +154,7 @@
 								<name>Groovy Eclipse Latest Release for Eclipse @item@</name>
 								<target>${project.build.directory}/site/@item@</target>
 								<sites>
-									<param>http://dist.springsource.org/release/GRECLIPSE/${dist.version}/@item@</param>
+									<param>https://dist.springsource.org/release/GRECLIPSE/${dist.version}/@item@</param>
 								</sites>
 							</configuration>
 							</pluginExecutor>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://wiki.eclipse.org/Tycho/Packaging_Types (200) with 1 occurrences could not be migrated:  
   ([https](https://wiki.eclipse.org/Tycho/Packaging_Types) result SSLException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://codehaus.org (UnknownHostException) with 1 occurrences migrated to:  
  https://codehaus.org ([https](https://codehaus.org) result UnknownHostException).
* [ ] http://dist.codehaus.org/groovy/distributions/greclipse/groovy-m2eclipse/ (UnknownHostException) with 1 occurrences migrated to:  
  https://dist.codehaus.org/groovy/distributions/greclipse/groovy-m2eclipse/ ([https](https://dist.codehaus.org/groovy/distributions/greclipse/groovy-m2eclipse/) result UnknownHostException).
* [ ] http://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2 (UnknownHostException) with 1 occurrences migrated to:  
  https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2 ([https](https://dist.codehaus.org/groovy/distributions/greclipse/snapshot/e4.2) result UnknownHostException).
* [ ] http://docs.codehaus.org/display/GROOVY/Groovy-Eclipse+compiler+plugin+for+Maven (UnknownHostException) with 1 occurrences migrated to:  
  https://docs.codehaus.org/display/GROOVY/Groovy-Eclipse+compiler+plugin+for+Maven ([https](https://docs.codehaus.org/display/GROOVY/Groovy-Eclipse+compiler+plugin+for+Maven) result UnknownHostException).
* [ ] http://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide (UnknownHostException) with 2 occurrences migrated to:  
  https://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide ([https](https://docs.codehaus.org/display/HAUSMATES/Codehaus+Maven+Repository+Usage+Guide) result UnknownHostException).
* [ ] http://groovy.codehaus.org/Eclipse+Plugin (UnknownHostException) with 1 occurrences migrated to:  
  https://groovy.codehaus.org/Eclipse+Plugin ([https](https://groovy.codehaus.org/Eclipse+Plugin) result UnknownHostException).
* [ ] http://jira.codehaus.org/browse/GRECLIPSE (UnknownHostException) with 1 occurrences migrated to:  
  https://jira.codehaus.org/browse/GRECLIPSE ([https](https://jira.codehaus.org/browse/GRECLIPSE) result UnknownHostException).
* [ ] http://svn.codehaus.org/groovy/eclipse (UnknownHostException) with 2 occurrences migrated to:  
  https://svn.codehaus.org/groovy/eclipse ([https](https://svn.codehaus.org/groovy/eclipse) result UnknownHostException).
* [ ] http://download.eclipse.org/eclipse/updates/4.3-P-builds/ (404) with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.3-P-builds/ ([https](https://download.eclipse.org/eclipse/updates/4.3-P-builds/) result 404).
* [ ] http://download.eclipse.org/eclipse/updates/4.8milestones (404) with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.8milestones ([https](https://download.eclipse.org/eclipse/updates/4.8milestones) result 404).
* [ ] http://repository.springsource.com/maven/bundles/release (404) with 2 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://aniefer.blogspot.com/2009/06/patching-features-part-2.html with 1 occurrences migrated to:  
  https://aniefer.blogspot.com/2009/06/patching-features-part-2.html ([https](https://aniefer.blogspot.com/2009/06/patching-features-part-2.html) result 200).
* [ ] http://dist.springsource.org/release/GRECLIPSE/ with 1 occurrences migrated to:  
  https://dist.springsource.org/release/GRECLIPSE/ ([https](https://dist.springsource.org/release/GRECLIPSE/) result 200).
* [ ] http://maven.apache.org/xsd/archetype-1.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/archetype-1.0.0.xsd ([https](https://maven.apache.org/xsd/archetype-1.0.0.xsd) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 103 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://maven.apache.org/xsd/settings-1.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/settings-1.0.0.xsd ([https](https://maven.apache.org/xsd/settings-1.0.0.xsd) result 200).
* [ ] http://www.eclipse.org/legal/epl-v10.html with 167 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* [ ] http://www.eclipse.org/org/documents/edl-v10.php with 40 occurrences migrated to:  
  https://www.eclipse.org/org/documents/edl-v10.php ([https](https://www.eclipse.org/org/documents/edl-v10.php) result 200).
* [ ] http://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html with 1 occurrences migrated to:  
  https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html ([https](https://www.eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html) result 200).
* [ ] http://download.eclipse.org/eclipse/updates/3.7 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/3.7 ([https](https://download.eclipse.org/eclipse/updates/3.7) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.2 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.2 ([https](https://download.eclipse.org/eclipse/updates/4.2) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.3 with 2 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.3 ([https](https://download.eclipse.org/eclipse/updates/4.3) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.4 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.4 ([https](https://download.eclipse.org/eclipse/updates/4.4) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.5 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.5 ([https](https://download.eclipse.org/eclipse/updates/4.5) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.6 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.6 ([https](https://download.eclipse.org/eclipse/updates/4.6) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510 ([https](https://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510) result 301).
* [ ] http://download.eclipse.org/eclipse/updates/4.8 with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.8 ([https](https://download.eclipse.org/eclipse/updates/4.8) result 301).
* [ ] http://download.eclipse.org/releases/indigo with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/indigo ([https](https://download.eclipse.org/releases/indigo) result 301).
* [ ] http://download.eclipse.org/releases/juno with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/juno ([https](https://download.eclipse.org/releases/juno) result 301).
* [ ] http://download.eclipse.org/releases/kepler with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/kepler ([https](https://download.eclipse.org/releases/kepler) result 301).
* [ ] http://download.eclipse.org/releases/luna with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/luna ([https](https://download.eclipse.org/releases/luna) result 301).
* [ ] http://download.eclipse.org/releases/mars with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/mars ([https](https://download.eclipse.org/releases/mars) result 301).
* [ ] http://download.eclipse.org/releases/neon with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/neon ([https](https://download.eclipse.org/releases/neon) result 301).
* [ ] http://download.eclipse.org/releases/oxygen/201712201001 with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/oxygen/201712201001 ([https](https://download.eclipse.org/releases/oxygen/201712201001) result 301).
* [ ] http://download.eclipse.org/releases/photon with 1 occurrences migrated to:  
  https://download.eclipse.org/releases/photon ([https](https://download.eclipse.org/releases/photon) result 301).
* [ ] http://download.eclipse.org/technology/epp/updates/1.0 with 1 occurrences migrated to:  
  https://download.eclipse.org/technology/epp/updates/1.0 ([https](https://download.eclipse.org/technology/epp/updates/1.0) result 301).
* [ ] http://github.com/groovy/groovy-eclipse.git with 1 occurrences migrated to:  
  https://github.com/groovy/groovy-eclipse.git ([https](https://github.com/groovy/groovy-eclipse.git) result 301).
* [ ] http://maven.apache.org/maven-v4_0_0.xsd with 16 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* [ ] http://repo.spring.io/plugins-snapshot-local with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-snapshot-local ([https](https://repo.spring.io/plugins-snapshot-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://eclipse.org/component with 18 occurrences
* http://maven.apache.org/POM/4.0.0 with 240 occurrences
* http://maven.apache.org/plugins/maven-archetype-plugin/archetype/1.0.0 with 2 occurrences
* http://www.w3.org/2000/svg with 9 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 130 occurrences