### PR TITLE
Fix broken ref in groovy-eclipse setup model

### DIFF
--- a/groovy-eclipse.setup
+++ b/groovy-eclipse.setup
@@ -354,7 +354,7 @@
             pattern="org\.codehaus\.groovy\.(m2)?eclipse.*"/>
         <operand
             xsi:type="workingsets:ExclusionPredicate"
-            excludedWorkingSet="//@setupTasks.13/@workingSets.3"/>
+            excludedWorkingSet="//@setupTasks.21/@workingSets.3"/>
       </predicate>
     </workingSet>
     <workingSet


### PR DESCRIPTION
Hi, I was asked by the setup maintainer to fix this broken ref in the setup model, because it creates errors when the catalog is assembled. 

