### PR TITLE
Lower Maven requirement of groovy-eclipse-compiler to 3.3.9

### DIFF
--- a/extras/groovy-eclipse-compiler/pom.xml
+++ b/extras/groovy-eclipse-compiler/pom.xml
@@ -39,6 +39,10 @@
 		<url>https://github.com/groovy/groovy-eclipse/issues</url>
 	</issueManagement>
 
+	<prerequisites>
+		<maven>${maven.version}</maven>
+	</prerequisites>
+
 	<scm>
 		<url>https://github.com/groovy/groovy-eclipse.git</url>
 		<connection>scm:git://github.com/groovy/groovy-eclipse.git</connection>
@@ -50,12 +54,14 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<version>3.6.0</version>
+			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.6.0</version>
+			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
@@ -84,6 +90,8 @@
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- Lowest Maven version this project can be used with -->
+		<maven.version>3.3.9</maven.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This lowers the API and Maven version the groovy-eclipse-compiler can be used with.

Currently, running on lower Maven versions seems to work most of the time, but in combination with the Jenkins [pipeline-maven-plugin](https://github.com/jenkinsci/pipeline-maven-plugin), random errors are thrown in the build process...

This lowers the Maven version to 3.3.9 (selected since it reasonably old and the version currently in Debian stable, for totally unselfish reasons 😉)

Additionally, this adds the `<prerequisites>` tag, so Maven will throw an error when executed on an older version of Maven.

PS: Using an older minimum version would probably still work, but I'd suggest not going lower then [3.1.0](http://maven.apache.org/maven-logging.html)...