### PR TITLE
Added initial support for `<failOnWarning>` configuration.

### DIFF
--- a/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
+++ b/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
@@ -294,7 +294,7 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             args.put("-deprecation", null);
         }
         if (config.isFailOnWarning()) {
-            args.put("-proceedOnError:Fatal", null);
+            args.put("-failOnWarning", null);
         }
         if (!config.isShowWarnings()) {
             args.put("-nowarn", null);

--- a/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
+++ b/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
@@ -297,9 +297,9 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
         if (config.isShowDeprecation()) {
             args.put("-deprecation", null);
         }
-        /*if (config.isFailOnWarning()) {
-            args.put("-err:TODO", null);
-        }*/
+        if (config.isFailOnWarning()) {
+            args.put("-failOnWarning", null);
+        }
         if (!config.isShowWarnings()) {
             args.put("-nowarn", null);
         }

--- a/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
+++ b/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
@@ -122,12 +122,18 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             if (verbose) getLogger().info("Compiler arguments: " + Arrays.toString(args));
             InternalCompiler.Result result = InternalCompiler.doCompile(args, out, getLogger(), verbose);
 
-            List<CompilerMessage> messages = parseMessages(result.success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
-            if (!result.success) {
-                messages.add(formatFailure(result.globalErrorsCount, result.globalWarningsCount));
+            boolean success = result.success;
+            boolean failOnWarning = config.isFailOnWarning();
+            if (failOnWarning && result.globalWarningsCount > 0) {
+                success = false;
             }
 
-            return new CompilerResult(result.success, messages);
+            List<CompilerMessage> messages = parseMessages(success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
+            if (!success) {
+                messages.add(formatFailure(result.globalErrorsCount, result.globalWarningsCount, failOnWarning));
+            }
+
+            return new CompilerResult(success, messages);
         }
     }
 
@@ -167,29 +173,40 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             try {
                 staleSources.addAll(scanner.getIncludedSources(sourcePath, outputDirectory));
             } catch (InclusionScanException e) {
-                throw new CompilerException("Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
+                throw new CompilerException(
+                        "Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
             }
         }
 
         return staleSources;
     }
 
-    private CompilerMessage formatFailure(int globalErrorsCount, int globalWarningsCount) {
+    private CompilerMessage formatFailure(int globalErrorsCount, int globalWarningsCount, boolean failOnWarning) {
         Kind kind;
         if (globalErrorsCount > 0) {
             kind = Kind.ERROR;
         } else if (globalWarningsCount > 0) {
-            kind = Kind.WARNING;
+            if (failOnWarning) {
+                kind = Kind.ERROR;
+            } else {
+                kind = Kind.WARNING;
+            }
         } else {
             kind = Kind.NOTE;
         }
 
         String error = globalErrorsCount == 1 ? "error" : "errors";
         String warning = globalWarningsCount == 1 ? "warning" : "warnings";
-        return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + ".", kind);
+        String failedOnWarning = "";
+        if(failOnWarning){
+            if(globalErrorsCount == 0 && globalWarningsCount > 0) {
+                failedOnWarning = " Warnings found and failOnWarning specified.";
+            }
+        }
+        return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + "." + failedOnWarning, kind);
     }
 
-    private Map<String,String> composeSourceFiles(File[] sourceFiles) {
+    private Map<String, String> composeSourceFiles(File[] sourceFiles) {
         Map<String, String> sources = new DeduplicatingHashMap<>(getLogger(), sourceFiles.length);
         for (File sourceFile : sourceFiles) {
             sources.put(sourceFile.getPath(), null);
@@ -293,9 +310,9 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
         if (config.isShowDeprecation()) {
             args.put("-deprecation", null);
         }
-        if (config.isFailOnWarning()) {
-            args.put("-proceedOnError:Fatal", null);
-        }
+        /*if (config.isFailOnWarning()) {
+            args.put("-err:TODO", null);
+        }*/
         if (!config.isShowWarnings()) {
             args.put("-nowarn", null);
         }

--- a/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
+++ b/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
@@ -122,18 +122,12 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             if (verbose) getLogger().info("Compiler arguments: " + Arrays.toString(args));
             InternalCompiler.Result result = InternalCompiler.doCompile(args, out, getLogger(), verbose);
 
-            boolean success = result.success;
-            boolean failOnWarning = config.isFailOnWarning();
-            if (failOnWarning && result.globalWarningsCount > 0) {
-                success = false;
+            List<CompilerMessage> messages = parseMessages(result.success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
+            if (!result.success) {
+                messages.add(formatResult(result.success, result.globalErrorsCount, result.globalWarningsCount));
             }
 
-            List<CompilerMessage> messages = parseMessages(success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
-            if (!success) {
-                messages.add(formatFailure(result.globalErrorsCount, result.globalWarningsCount, failOnWarning));
-            }
-
-            return new CompilerResult(success, messages);
+            return new CompilerResult(result.success, messages);
         }
     }
 
@@ -173,40 +167,33 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             try {
                 staleSources.addAll(scanner.getIncludedSources(sourcePath, outputDirectory));
             } catch (InclusionScanException e) {
-                throw new CompilerException(
-                        "Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
+                throw new CompilerException("Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
             }
         }
 
         return staleSources;
     }
 
-    private CompilerMessage formatFailure(int globalErrorsCount, int globalWarningsCount, boolean failOnWarning) {
-        Kind kind;
-        if (globalErrorsCount > 0) {
-            kind = Kind.ERROR;
-        } else if (globalWarningsCount > 0) {
-            if (failOnWarning) {
-                kind = Kind.ERROR;
-            } else {
-                kind = Kind.WARNING;
-            }
+    private CompilerMessage formatResult(boolean result, int globalErrorsCount, int globalWarningsCount) {
+        if (result) {
+            return new CompilerMessage("Success!", Kind.NOTE);
         } else {
-            kind = Kind.NOTE;
-        }
-
-        String error = globalErrorsCount == 1 ? "error" : "errors";
-        String warning = globalWarningsCount == 1 ? "warning" : "warnings";
-        String failedOnWarning = "";
-        if(failOnWarning){
-            if(globalErrorsCount == 0 && globalWarningsCount > 0) {
-                failedOnWarning = " Warnings found and failOnWarning specified.";
+            Kind kind;
+            if (globalErrorsCount > 0) {
+                kind = Kind.ERROR;
+            } else if (globalWarningsCount > 0) {
+                kind = Kind.WARNING;
+            } else {
+                kind = Kind.NOTE;
             }
+
+            String error = globalErrorsCount == 1 ? "error" : "errors";
+            String warning = globalWarningsCount == 1 ? "warning" : "warnings";
+            return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + ".", kind);
         }
-        return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + "." + failedOnWarning, kind);
     }
 
-    private Map<String, String> composeSourceFiles(File[] sourceFiles) {
+    private Map<String,String> composeSourceFiles(File[] sourceFiles) {
         Map<String, String> sources = new DeduplicatingHashMap<>(getLogger(), sourceFiles.length);
         for (File sourceFile : sourceFiles) {
             sources.put(sourceFile.getPath(), null);
@@ -311,7 +298,7 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             args.put("-deprecation", null);
         }
         if (config.isFailOnWarning()) {
-            args.put("-failOnWarning", null);
+            args.put("-proceedOnError:Fatal", null);
         }
         if (!config.isShowWarnings()) {
             args.put("-nowarn", null);

--- a/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
+++ b/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
@@ -122,18 +122,12 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             if (verbose) getLogger().info("Compiler arguments: " + Arrays.toString(args));
             InternalCompiler.Result result = InternalCompiler.doCompile(args, out, getLogger(), verbose);
 
-            boolean success = result.success;
-            boolean failOnWarning = config.isFailOnWarning();
-            if (failOnWarning && result.globalWarningsCount > 0) {
-                success = false;
+            List<CompilerMessage> messages = parseMessages(result.success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
+            if (!result.success) {
+                messages.add(formatResult(result.success, result.globalErrorsCount, result.globalWarningsCount));
             }
 
-            List<CompilerMessage> messages = parseMessages(success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
-            if (!success) {
-                messages.add(formatFailure(result.globalErrorsCount, result.globalWarningsCount, failOnWarning));
-            }
-
-            return new CompilerResult(success, messages);
+            return new CompilerResult(result.success, messages);
         }
     }
 
@@ -173,40 +167,33 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
             try {
                 staleSources.addAll(scanner.getIncludedSources(sourcePath, outputDirectory));
             } catch (InclusionScanException e) {
-                throw new CompilerException(
-                        "Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
+                throw new CompilerException("Error scanning source root: \'" + sourceRoot + "\' for stale files to recompile.", e);
             }
         }
 
         return staleSources;
     }
 
-    private CompilerMessage formatFailure(int globalErrorsCount, int globalWarningsCount, boolean failOnWarning) {
-        Kind kind;
-        if (globalErrorsCount > 0) {
-            kind = Kind.ERROR;
-        } else if (globalWarningsCount > 0) {
-            if (failOnWarning) {
-                kind = Kind.ERROR;
-            } else {
-                kind = Kind.WARNING;
-            }
+    private CompilerMessage formatResult(boolean result, int globalErrorsCount, int globalWarningsCount) {
+        if (result) {
+            return new CompilerMessage("Success!", Kind.NOTE);
         } else {
-            kind = Kind.NOTE;
-        }
-
-        String error = globalErrorsCount == 1 ? "error" : "errors";
-        String warning = globalWarningsCount == 1 ? "warning" : "warnings";
-        String failedOnWarning = "";
-        if(failOnWarning){
-            if(globalErrorsCount == 0 && globalWarningsCount > 0) {
-                failedOnWarning = " Warnings found and failOnWarning specified.";
+            Kind kind;
+            if (globalErrorsCount > 0) {
+                kind = Kind.ERROR;
+            } else if (globalWarningsCount > 0) {
+                kind = Kind.WARNING;
+            } else {
+                kind = Kind.NOTE;
             }
+
+            String error = globalErrorsCount == 1 ? "error" : "errors";
+            String warning = globalWarningsCount == 1 ? "warning" : "warnings";
+            return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + ".", kind);
         }
-        return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + "." + failedOnWarning, kind);
     }
 
-    private Map<String, String> composeSourceFiles(File[] sourceFiles) {
+    private Map<String,String> composeSourceFiles(File[] sourceFiles) {
         Map<String, String> sources = new DeduplicatingHashMap<>(getLogger(), sourceFiles.length);
         for (File sourceFile : sourceFiles) {
             sources.put(sourceFile.getPath(), null);
@@ -310,9 +297,9 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
         if (config.isShowDeprecation()) {
             args.put("-deprecation", null);
         }
-        /*if (config.isFailOnWarning()) {
-            args.put("-err:TODO", null);
-        }*/
+        if (config.isFailOnWarning()) {
+            args.put("-proceedOnError:Fatal", null);
+        }
         if (!config.isShowWarnings()) {
             args.put("-nowarn", null);
         }

--- a/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
+++ b/extras/groovy-eclipse-compiler/src/main/java/org/codehaus/groovy/eclipse/compiler/GroovyEclipseCompiler.java
@@ -124,7 +124,7 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
 
             List<CompilerMessage> messages = parseMessages(result.success ? 0 : 1, out.getBuffer().toString(), config.isShowWarnings() || config.isVerbose());
             if (!result.success) {
-                messages.add(formatResult(result.success, result.globalErrorsCount, result.globalWarningsCount));
+                messages.add(formatFailure(result.globalErrorsCount, result.globalWarningsCount));
             }
 
             return new CompilerResult(result.success, messages);
@@ -174,23 +174,19 @@ public class GroovyEclipseCompiler extends AbstractCompiler {
         return staleSources;
     }
 
-    private CompilerMessage formatResult(boolean result, int globalErrorsCount, int globalWarningsCount) {
-        if (result) {
-            return new CompilerMessage("Success!", Kind.NOTE);
+    private CompilerMessage formatFailure(int globalErrorsCount, int globalWarningsCount) {
+        Kind kind;
+        if (globalErrorsCount > 0) {
+            kind = Kind.ERROR;
+        } else if (globalWarningsCount > 0) {
+            kind = Kind.WARNING;
         } else {
-            Kind kind;
-            if (globalErrorsCount > 0) {
-                kind = Kind.ERROR;
-            } else if (globalWarningsCount > 0) {
-                kind = Kind.WARNING;
-            } else {
-                kind = Kind.NOTE;
-            }
-
-            String error = globalErrorsCount == 1 ? "error" : "errors";
-            String warning = globalWarningsCount == 1 ? "warning" : "warnings";
-            return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + ".", kind);
+            kind = Kind.NOTE;
         }
+
+        String error = globalErrorsCount == 1 ? "error" : "errors";
+        String warning = globalWarningsCount == 1 ? "warning" : "warnings";
+        return new CompilerMessage("Found " + globalErrorsCount + " " + error + " and " + globalWarningsCount + " " + warning + ".", kind);
     }
 
     private Map<String,String> composeSourceFiles(File[] sourceFiles) {


### PR DESCRIPTION
Hey

The PR allows users to specify the `failOnWarning` flag in the `maven-compiler-plugin` configuration like so:

````XML
...
<plugin>
    <artifactId>maven-compiler-plugin</artifactId>
    <version>3.8.0</version>
    <configuration>
        <compilerId>groovy-eclipse-compiler</compilerId>
        <showWarnings>true</showWarnings>
        <failOnWarning>true</failOnWarning>
        <compilerArgs>
            <arg>-warn:+all</arg>
         </compilerArgs>
    </configuration>
</plugin>    
````

A simple Java class:

````java
public class Main {
    public void foo() {       
    }
}
````
This leads to a warning: `Empty block should be documented`, which when `failOnWarning` is set gives the following error: 

````
[ERROR] Found 0 errors and 1 warning. Warnings found and failOnWarning specified.
````

I couldn't figure out how to write a proper test in the `groovy-eclipse-compiler-tests` project, but I would love if you could point me in the right direction.

Best regards