### PR TITLE
Indent nested method-call argument lists (#591)

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_NestedCalls_GRE_591.txt
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_NestedCalls_GRE_591.txt
@@ -1,0 +1,46 @@
+###prop
+setPreferences=true
+indentendOnly=true
+###src
+class Formatting {
+	StringBuilder m1() {
+		return new StringBuilder();
+	}
+	StringBuilder m2(String p1, StringBuilder p2) {
+		return new StringBuilder();
+	}
+
+	def main(args) {
+		println(m1().
+				append("a").
+				append("b").
+				append("c").
+				append(m2(
+				"x",
+				m1().
+				append("aa").
+				append("ab"))))
+	}
+}
+###exp
+class Formatting {
+	StringBuilder m1() {
+		return new StringBuilder();
+	}
+	StringBuilder m2(String p1, StringBuilder p2) {
+		return new StringBuilder();
+	}
+
+	def main(args) {
+		println(m1().
+				append("a").
+				append("b").
+				append("c").
+				append(m2(
+						"x",
+						m1().
+						append("aa").
+						append("ab"))))
+	}
+}
+###end

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyIndentation.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyIndentation.java
@@ -15,6 +15,8 @@
  */
 package org.codehaus.groovy.eclipse.refactoring.formatter;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -79,6 +81,9 @@ public class GroovyIndentation {
 
         // GRECLIPSE-1478
         handleMultilineMethodParameters();
+
+        // GRECLIPSE issue #591
+        handleNestedParenWraps();
 
         try {
             Token firstToken = tokens.get(0);
@@ -234,6 +239,45 @@ public class GroovyIndentation {
                         }
                         if (doLastLineIndent) {
                             tempIndentation[lineEnd - 1] += indentationMultiline;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // https://github.com/groovy/groovy-eclipse/issues/591
+    // Adds extra indentation for nested method-call argument lists whose
+    // contents start on a line after the opening paren. Each such paren pair
+    // that is itself contained within another paren (i.e. not the outermost
+    // paren of the statement) contributes one additional indentationMultiline
+    // to the lines it spans. The outermost wrap is already handled by the
+    // multiline-statement rule in getIndentationEdits.
+    private void handleNestedParenWraps() {
+        int indentationMultiline = pref.getIndentationMultiline();
+        // Each entry: { openLine, isWrapOpen (1/0), enclosingDepth }
+        Deque<int[]> parenStack = new ArrayDeque<>();
+
+        for (int i = 0, n = tokens.size(); i < n; i++) {
+            Token token = tokens.get(i);
+            int ttype = token.getType();
+            if (ttype == GroovyTokenTypeBridge.LPAREN) {
+                Token nextNonNLS = formatter.getNextToken(i);
+                boolean isWrapOpen = (nextNonNLS != null && nextNonNLS.getLine() > token.getLine());
+                int enclosingDepth = parenStack.size();
+                parenStack.push(new int[] {token.getLine(), isWrapOpen ? 1 : 0, enclosingDepth});
+            } else if (ttype == GroovyTokenTypeBridge.RPAREN) {
+                if (!parenStack.isEmpty()) {
+                    int[] entry = parenStack.pop();
+                    int openLine = entry[0];
+                    boolean wasWrapOpen = entry[1] != 0;
+                    int enclosingDepth = entry[2];
+                    int closeLine = token.getLine();
+
+                    if (wasWrapOpen && enclosingDepth > 0 && closeLine > openLine) {
+                        for (int line = openLine + 1; line <= closeLine; line++) {
+                            tempIndentation[line - 1] += indentationMultiline;
+                            lineInd.setMultilineIndentation(line, true);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #591. Adds extra indentation for nested method-call argument lists whose contents start on a line after the opening paren.

For a multiline statement like

```groovy
println(m1().
        append("a").
        append("b").
        append(m2(
        "x",
        m1())))
```

the existing formatter applies a single multiline indent to every continuation line, so `"x"` and `m1()` (inside `m2(...)`) end up at the same column as `.append(...)` from the outer chain. The new `handleNestedParenWraps` pass in `GroovyIndentation` walks the tokens and, for each paren pair that
- opens with content on the next line (a wrap-open), and
- is itself contained within another paren

adds another `indentationMultiline` step to the lines it spans. The outermost wrap is left to the existing multiline-statement rule, so the single-level fixtures (`MultilineStatements1/3`, `MultilineMethodParams*`, etc.) are unchanged.