### PR TITLE
break single-line closures that exceed max line length

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_GRE_624.txt
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_GRE_624.txt
@@ -1,0 +1,18 @@
+###prop
+setPreferences=true
+maxLineLegth=100
+###src
+def sphinxJson = addTaskLocal([name: BUILD_DOCS_JSON, type: SphinxDocumentationTask]) { type = SphinxDocType.JSON }
+def short_one = doStuff() { foo() }
+def empty_one = doStuff() {}
+def long_with_params = aMethodWithAReallyLongName(arg1, arg2) { it, ix -> doSomethingMeaningful(it, ix) }
+###exp
+def sphinxJson = addTaskLocal([name: BUILD_DOCS_JSON, type: SphinxDocumentationTask]) {
+	type = SphinxDocType.JSON
+}
+def short_one = doStuff() { foo() }
+def empty_one = doStuff() {}
+def long_with_params = aMethodWithAReallyLongName(arg1, arg2) { it, ix ->
+	doSomethingMeaningful(it, ix)
+}
+###end

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyBeautifier.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyBeautifier.java
@@ -90,10 +90,12 @@ public class GroovyBeautifier {
                 }
                 posCLEnd = positionLastTokenOfClosure;
             }
-            // ignore closure on one line
+            // ignore closure on one line, unless that line exceeds the configured max length
             if (clExp.getLineNumber() == clExp.getLastLineNumber()) {
-                ignoreToken.add(formatter.getTokens().get(posCLEnd));
-                continue;
+                if (!exceedsMaxLineLength(clExp.getLineNumber()) || !hasStatements(clExp)) {
+                    ignoreToken.add(formatter.getTokens().get(posCLEnd));
+                    continue;
+                }
             }
 
             if (clExp.getCode() instanceof BlockStatement) {
@@ -189,6 +191,24 @@ public class GroovyBeautifier {
             }
         }
         return false;
+    }
+
+    private boolean hasStatements(ClosureExpression node) {
+        return (node.getCode() instanceof BlockStatement) &&
+            !((BlockStatement) node.getCode()).getStatements().isEmpty();
+    }
+
+    private boolean exceedsMaxLineLength(int lineNumber) {
+        try {
+            IDocument doc = formatter.getProgressDocument();
+            int lineIndex = lineNumber - 1; // line numbers are 1-based
+            if (lineIndex < 0 || lineIndex >= doc.getNumberOfLines()) {
+                return false;
+            }
+            return doc.getLineInformation(lineIndex).getLength() > preferences.getMaxLineLength();
+        } catch (BadLocationException e) {
+            return false;
+        }
     }
 
     private void replaceNLSWithSpace(MultiTextEdit container, int startPos, int endPos) throws BadLocationException {


### PR DESCRIPTION
## Summary

Closes #624.

When a closure fit on a single line per its AST positions, the formatter previously left it alone unconditionally. This caused lines that join a short closure body with surrounding context (e.g. a long method call followed by a trailing closure) to exceed `groovy.formatter.line.maxlength` with no recourse from the formatter.

`combineClosures` now keeps the "ignore single-line closure" shortcut only when the line is within the configured max length, or when the closure has no statements (so `{}` is still preserved). Otherwise the closure falls through to the existing multi-line code path: a newline is inserted after `{` (or after `->` when parameters are specified), and `correctBraces` handles the closing `}` via its existing `rCurlyEditor`.

Example with `groovy.formatter.line.maxlength=100`:

Before:
```groovy
def sphinxJson = addTaskLocal([name: BUILD_DOCS_JSON, type: SphinxDocumentationTask]) { type = SphinxDocType.JSON }
```

After:
```groovy
def sphinxJson = addTaskLocal([name: BUILD_DOCS_JSON, type: SphinxDocumentationTask]) {
    type = SphinxDocType.JSON
}
```

`Formatter_Test_GRE_624.txt` covers four cases: the bug's exact reproduction (broken), a short single-line closure (unchanged), an empty `{}` closure (unchanged), and a closure with explicit parameters on a too-long line (`->` line kept, body wrapped).