### PR TITLE
fix method reference formatting

### DIFF
--- a/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_MethodReference_spotless_3013.txt
+++ b/ide-test/org.codehaus.groovy.eclipse.refactoring.test/resources/Formatter/Formatter_Test_MethodReference_spotless_3013.txt
@@ -1,0 +1,8 @@
+###prop
+setPreferences=true
+indentendOnly=false
+###src
+s.write(tests, TestFQNSerializer::serialize)
+###exp
+s.write(tests, TestFQNSerializer::serialize)
+###end

--- a/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyBeautifier.java
+++ b/ide/org.codehaus.groovy.eclipse.refactoring/src/org/codehaus/groovy/eclipse/refactoring/formatter/GroovyBeautifier.java
@@ -371,6 +371,11 @@ public class GroovyBeautifier {
 
     private void addAdditionalSpacing(MultiTextEdit edits) {
         try {
+            // Tracks whether the previous token was the first colon of a
+            // split "::" method reference operator, so the second colon
+            // (whose own next token is not a colon) is also exempted from
+            // the COLON-triggers-a-trailing-space rule below.
+            boolean previousWasFirstHalfOfMethodReference = false;
             for (Token token : formatter.getTokens().getTokens(formatter.selection)) {
                 Token nextToken = formatter.getTokens().getNextToken(token);
                 int tokenType = token.getType();
@@ -413,7 +418,19 @@ public class GroovyBeautifier {
                     addSpaceAfter = true;
                 }
 
-                if (tokenType == GroovyTokenTypeBridge.COLON) {
+                boolean isSecondHalfOfMethodReference = previousWasFirstHalfOfMethodReference;
+                previousWasFirstHalfOfMethodReference = (tokenType == GroovyTokenTypeBridge.COLON && nextTokenType == GroovyTokenTypeBridge.COLON);
+
+                if (tokenType == GroovyTokenTypeBridge.COLON
+                        && nextTokenType != GroovyTokenTypeBridge.COLON
+                        && !isSecondHalfOfMethodReference) {
+                    // A COLON adjacent to another COLON (on either side) is
+                    // the method reference operator "::" (Groovy 3+), split
+                    // into two tokens because the legacy antlr2 grammar used
+                    // for formatting predates it and has no lookahead rule
+                    // for it. No legitimate Groovy construct produces two
+                    // adjacent colons, so this is always safe to assume.
+                    // Adding a space here would corrupt "::" (see spotless#3013).
                     addSpaceAfter = true;
                 }
 
@@ -486,6 +503,14 @@ public class GroovyBeautifier {
                 }
 
                 if (nextTokenType == GroovyTokenTypeBridge.COMMA) {
+                    removeAllWhitespaces = true;
+                }
+
+                if (tokenType == GroovyTokenTypeBridge.COLON && nextTokenType == GroovyTokenTypeBridge.COLON) {
+                    // Two adjacent colons are always the "::" method
+                    // reference operator split by the legacy grammar (see
+                    // spotless#3013); normalize any stray spacing back to
+                    // zero rather than collapsing it to one space.
                     removeAllWhitespaces = true;
                 }
 


### PR DESCRIPTION
The Groovy method reference operator :: (e.g. TestFQNSerializer::serialize) gets corrupted to : : by the formatter, producing invalid Groovy that fails to compile. Reported via [diffplug/spotless#3013](https://github.com/diffplug/spotless/issues/3013).